### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Maintenance
+
+- Require Go 1.26.6 and refresh the pinned Go container images for the latest standard-library security fixes.
+
 ## 0.13.1 - 2026-08-09
 
 **Highlight:** `tail --verbose` now tells you *why* a message was not archived.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
+ARG GO_IMAGE_DIGEST=sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df
 ARG ALPINE_VERSION=3.24
 
-FROM golang:${GO_VERSION}-alpine AS build
+FROM golang:${GO_VERSION}-alpine@${GO_IMAGE_DIGEST} AS build
 RUN apk add --no-cache ca-certificates git
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/openclaw/discrawl/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/openclaw/discrawl/actions/workflows/ci.yml)
 [![GitHub release](https://img.shields.io/github/v/release/openclaw/discrawl?style=flat-square)](https://github.com/openclaw/discrawl/releases/latest)
-[![Go](https://img.shields.io/badge/Go-1.26.5%2B-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26.6%2B-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/github/license/openclaw/discrawl?style=flat-square)](LICENSE)
 [![Homebrew](https://img.shields.io/badge/Homebrew-openclaw%2Ftap-FBB040?style=flat-square&logo=homebrew&logoColor=black)](https://github.com/openclaw/homebrew-tap/blob/main/Formula/discrawl.rb)
 [![Docs](https://img.shields.io/badge/docs-discrawl.sh-4C78A8?style=flat-square)](https://discrawl.sh/)
@@ -22,7 +22,7 @@ discrawl --version
 
 Windows binaries and signed archives for all supported platforms are available from [GitHub Releases](https://github.com/openclaw/discrawl/releases/latest).
 
-To build from source, install Go 1.26.5 or newer:
+To build from source, install Go 1.26.6 or newer:
 
 ```bash
 git clone https://github.com/openclaw/discrawl.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/discrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.1

--- a/scripts/docker-git-source-smoke.sh
+++ b/scripts/docker-git-source-smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_root="$(git -C "$(dirname "${BASH_SOURCE[0]}")/.." rev-parse --show-toplevel)"
-image="${DISCRAWL_DOCKER_IMAGE:-golang:1.26.5-bookworm}"
+image="${DISCRAWL_DOCKER_IMAGE:-golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36}"
 tmp="$(mktemp -d /tmp/discrawl-docker-smoke.XXXXXX)"
 cleanup() {
   rm -rf "$tmp"


### PR DESCRIPTION
## Summary

- raise the module and documented Go floor to 1.26.6
- refresh the Alpine and Bookworm Go image pins with Docker Hub digests published for 1.26.6
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Verification

- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 go vet ./...`
- `GOTOOLCHAIN=go1.26.6 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no reachable vulnerabilities
- built and ran the Dockerfile image against the pinned Alpine digest
- built and ran the CLI locally with isolated XDG directories
- autoreview clean
