### PR TITLE
fix: skip Discord members with a nil user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Skip Discord members with a missing user object during pagination and record conversion so public sync no longer panics on a nil `User`.
+- Skip Discord members with a missing user object during pagination and record conversion so public sync no longer panics on a nil `User`. Thanks @SebTardif.
 
 ## v0.13.2 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Skip Discord members with a missing user object during pagination and record conversion so public sync no longer panics on a nil `User`.
+
 ## v0.13.2 - 2026-08-14
 
 ### Maintenance

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -394,10 +394,14 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 		if len(page) < 1000 {
 			return out, nil
 		}
-		after = lastMemberUserID(page)
-		if after == "" {
+		nextAfter := lastMemberUserID(page)
+		if nextAfter == "" {
 			return nil, fmt.Errorf("guild %s member page missing user id", guildID)
 		}
+		if nextAfter == after {
+			return nil, fmt.Errorf("guild %s member page cursor did not advance", guildID)
+		}
+		after = nextAfter
 	}
 }
 
@@ -409,8 +413,8 @@ func memberUserID(member *discordgo.Member) string {
 }
 
 func lastMemberUserID(page []*discordgo.Member) string {
-	for i := len(page) - 1; i >= 0; i-- {
-		if id := memberUserID(page[i]); id != "" {
+	for _, member := range slices.Backward(page) {
+		if id := memberUserID(member); id != "" {
 			return id
 		}
 	}

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -385,12 +385,36 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 		if len(page) == 0 {
 			return out, nil
 		}
-		out = append(out, page...)
-		after = page[len(page)-1].User.ID
+		for _, member := range page {
+			if memberUserID(member) == "" {
+				continue
+			}
+			out = append(out, member)
+		}
 		if len(page) < 1000 {
 			return out, nil
 		}
+		after = lastMemberUserID(page)
+		if after == "" {
+			return nil, fmt.Errorf("guild %s member page missing user id", guildID)
+		}
 	}
+}
+
+func memberUserID(member *discordgo.Member) string {
+	if member == nil || member.User == nil {
+		return ""
+	}
+	return member.User.ID
+}
+
+func lastMemberUserID(page []*discordgo.Member) string {
+	for i := len(page) - 1; i >= 0; i-- {
+		if id := memberUserID(page[i]); id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 func (c *Client) ChannelMessages(ctx context.Context, channelID string, limit int, beforeID, afterID string) ([]*discordgo.Message, error) {

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -169,6 +169,134 @@ func TestClientRESTWrappers(t *testing.T) {
 	require.Equal(t, "m1", message.ID)
 }
 
+func TestGuildMembersSkipsNilUser(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/guilds/g1/members", writeJSON([]map[string]any{
+		{
+			"guild_id": "g1",
+			"user":     map[string]any{"id": "u1", "username": "peter"},
+			"roles":    []string{},
+		},
+		{
+			"guild_id": "g1",
+			"roles":    []string{},
+		},
+	}))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	t.Cleanup(restore)
+
+	client, err := New("token")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	var members []*discordgo.Member
+	require.NotPanics(t, func() {
+		members, err = client.GuildMembers(context.Background(), "g1")
+	})
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	require.Equal(t, "u1", members[0].User.ID)
+}
+
+func TestGuildMembersPaginatesFromLastValidUser(t *testing.T) {
+	firstPage := make([]map[string]any, 1000)
+	for i := range 999 {
+		firstPage[i] = map[string]any{
+			"guild_id": "g1",
+			"user":     map[string]any{"id": fmt.Sprintf("u%04d", i), "username": "user"},
+			"roles":    []string{},
+		}
+	}
+	firstPage[999] = map[string]any{
+		"guild_id": "g1",
+		"roles":    []string{},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/guilds/g1/members", func(w http.ResponseWriter, r *http.Request) {
+		after := r.URL.Query().Get("after")
+		switch after {
+		case "":
+			writeJSON(firstPage)(w, r)
+		case "u0998":
+			writeJSON([]map[string]any{
+				{
+					"guild_id": "g1",
+					"user":     map[string]any{"id": "u1000", "username": "tail"},
+					"roles":    []string{},
+				},
+			})(w, r)
+		default:
+			t.Errorf("unexpected after=%q", after)
+			writeJSON([]map[string]any{})(w, r)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	t.Cleanup(restore)
+
+	client, err := New("token")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	var members []*discordgo.Member
+	require.NotPanics(t, func() {
+		members, err = client.GuildMembers(context.Background(), "g1")
+	})
+	require.NoError(t, err)
+	require.Len(t, members, 1000)
+	require.Equal(t, "u0000", members[0].User.ID)
+	require.Equal(t, "u0998", members[998].User.ID)
+	require.Equal(t, "u1000", members[999].User.ID)
+}
+
+func TestGuildMembersErrorsWhenFullPageHasNoUser(t *testing.T) {
+	page := make([]map[string]any, 1000)
+	for i := range page {
+		page[i] = map[string]any{"guild_id": "g1", "roles": []string{}}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/guilds/g1/members", writeJSON(page))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	t.Cleanup(restore)
+
+	client, err := New("token")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	var members []*discordgo.Member
+	require.NotPanics(t, func() {
+		members, err = client.GuildMembers(context.Background(), "g1")
+	})
+	require.ErrorContains(t, err, "member page missing user id")
+	require.Nil(t, members)
+}
+
+func TestLastMemberUserID(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, lastMemberUserID(nil))
+	require.Empty(t, lastMemberUserID([]*discordgo.Member{
+		{User: nil},
+		nil,
+	}))
+	require.Equal(t, "u2", lastMemberUserID([]*discordgo.Member{
+		{User: &discordgo.User{ID: "u1"}},
+		{User: &discordgo.User{ID: "u2"}},
+		{User: nil},
+		nil,
+	}))
+}
+
 func TestTailRequiresHandler(t *testing.T) {
 	client, err := New("token")
 	require.NoError(t, err)

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -281,6 +281,39 @@ func TestGuildMembersErrorsWhenFullPageHasNoUser(t *testing.T) {
 	require.Nil(t, members)
 }
 
+func TestGuildMembersErrorsWhenCursorDoesNotAdvance(t *testing.T) {
+	page := make([]map[string]any, 1000)
+	page[0] = map[string]any{
+		"guild_id": "g1",
+		"user":     map[string]any{"id": "u1", "username": "peter"},
+		"roles":    []string{},
+	}
+	for i := 1; i < len(page); i++ {
+		page[i] = map[string]any{"guild_id": "g1", "roles": []string{}}
+	}
+
+	requests := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/guilds/g1/members", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		writeJSON(page)(w, r)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	t.Cleanup(restore)
+
+	client, err := New("token")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	members, err := client.GuildMembers(context.Background(), "g1")
+	require.ErrorContains(t, err, "member page cursor did not advance")
+	require.Nil(t, members)
+	require.Equal(t, 2, requests)
+}
+
 func TestLastMemberUserID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/records.go
+++ b/internal/syncer/records.go
@@ -13,6 +13,9 @@ import (
 )
 
 func toMemberRecord(guildID string, member *discordgo.Member) store.MemberRecord {
+	if member == nil || member.User == nil {
+		return store.MemberRecord{}
+	}
 	raw := marshalJSONString(member, "{}")
 	roles := marshalJSONString(member.Roles, "[]")
 	return store.MemberRecord{

--- a/internal/syncer/records_test.go
+++ b/internal/syncer/records_test.go
@@ -1,0 +1,73 @@
+package syncer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestToMemberRecordSkipsNilUser(t *testing.T) {
+	t.Parallel()
+
+	var rec store.MemberRecord
+	require.NotPanics(t, func() {
+		rec = toMemberRecord("g1", &discordgo.Member{User: nil})
+	})
+	require.Empty(t, rec.UserID)
+
+	require.NotPanics(t, func() {
+		rec = toMemberRecord("g1", nil)
+	})
+	require.Empty(t, rec.UserID)
+
+	rec = toMemberRecord("g1", &discordgo.Member{
+		User: &discordgo.User{ID: "u1", Username: "peter", GlobalName: "Peter"},
+		Nick: "Pete",
+	})
+	require.Equal(t, "g1", rec.GuildID)
+	require.Equal(t, "u1", rec.UserID)
+	require.Equal(t, "peter", rec.Username)
+	require.Equal(t, "Peter", rec.GlobalName)
+	require.Equal(t, "Pete", rec.DisplayName)
+}
+
+func TestRefreshGuildMembersSkipsNilUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	client := &fakeClient{
+		members: map[string][]*discordgo.Member{
+			"g1": {
+				{GuildID: "g1", User: &discordgo.User{ID: "u1", Username: "peter"}},
+				{GuildID: "g1", User: nil},
+				nil,
+			},
+		},
+	}
+	svc := New(client, s, nil)
+
+	var count int
+	require.NotPanics(t, func() {
+		count, err = svc.refreshGuildMembers(ctx, "g1", true)
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	status, err := s.Status(ctx, "db", "")
+	require.NoError(t, err)
+	require.Equal(t, 1, status.MemberCount)
+
+	rows, err := s.Members(ctx, "g1", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "u1", rows[0].UserID)
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -370,7 +370,11 @@ func (s *Syncer) refreshGuildMembers(ctx context.Context, guildID string, force 
 	}
 	converted := make([]store.MemberRecord, 0, len(members))
 	for _, member := range members {
-		converted = append(converted, toMemberRecord(guildID, member))
+		rec := toMemberRecord(guildID, member)
+		if rec.UserID == "" {
+			continue
+		}
+		converted = append(converted, rec)
 	}
 	if err := s.store.MergeMembers(ctx, guildID, converted); err != nil {
 		s.logger.Warn("member merge failed", "guild_id", guildID, "err", err)


### PR DESCRIPTION
## What Problem This Solves

`discordgo.Member.User` is a pointer. `discrawl sync` paginated members with `page[len-1].User.ID` and converted records with `member.User.ID`. A member with a missing `user` object panics the CLI.

## Evidence

```console
Red: TestToMemberRecordSkipsNilUser panicked on records.go User.ID
Green: GOWORK=off go test -count=1 ./...
```

Nil-user members are skipped. A full 1000-member page with no usable user ID errors instead of looping.

## Real behavior proof
Behavior addressed: Discord members with a nil User no longer crash pagination or record conversion.
Real environment tested: macOS, Go from the worktree, discrawl `/tmp/oc-impl-discrawl` head `8365a62`.
Exact steps or command run after this patch: `GOWORK=off go test -count=1 ./...`
Evidence after fix: red/green recorded above.
Observed result after fix: `Member{User: nil}` is skipped; last valid user ID is used as the page cursor.
What was not tested: A live Discord guild that actually returns members without `user`.
