### PR TITLE
fix: support exact snapshot updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Add persistent exact snapshot updates for dedicated Git-only readers so rows omitted by a newer filtered snapshot are removed without changing the merge-by-default behavior of richer local archives.
 - Skip Discord members with a missing user object during pagination and record conversion so public sync no longer panics on a nil `User`. Thanks @SebTardif.
 
 ## v0.13.2 - 2026-08-14

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ discrawl publish --check
 discrawl publish
 ```
 
-The preflight is read-only and reports the export scope before any snapshot is written. Published snapshots exclude wiretap direct messages and local failure history. See [Git snapshots](docs/guides/git-snapshots.md) for repository layout, filters, media handling, and update behavior.
+The preflight is read-only and reports the export scope before any snapshot is written. Published snapshots exclude wiretap direct messages and local failure history. Dedicated readers of privacy-filtered snapshots can subscribe with `--exact` so later omissions remove previously shared rows; normal subscriptions preserve richer local rows. See [Git snapshots](docs/guides/git-snapshots.md) for repository layout, filters, media handling, and update behavior.
 
 ## Automation
 

--- a/docs/commands/subscribe.md
+++ b/docs/commands/subscribe.md
@@ -14,6 +14,7 @@ discrawl subscribe --branch main https://github.com/example/discord-archive.git
 discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.git
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git
 discrawl subscribe --no-import https://github.com/example/discord-archive.git
+discrawl subscribe --exact https://github.com/example/public-archive.git
 discrawl subscribe --force https://github.com/example/discord-archive.git
 discrawl subscribe --with-embeddings https://github.com/example/discord-archive.git
 discrawl subscribe --no-media https://github.com/example/discord-archive.git
@@ -22,8 +23,9 @@ discrawl subscribe --no-media https://github.com/example/discord-archive.git
 ## What it does
 
 - writes a config with `discord.token_source = "none"` (so no bot token is required)
-- safely merges the latest snapshot into the local SQLite archive without deleting destination-only rows
+- safely merges the latest snapshot into the local SQLite archive without deleting destination-only rows by default
 - enables auto-refresh: read commands fetch and import when the local share import is older than `share.stale_after` (default `15m`)
+- with `--exact`, persists `share.update_mode = "exact"` and makes the initial import plus later manual and automatic updates mirror the current snapshot
 
 ## Flags
 
@@ -32,13 +34,16 @@ discrawl subscribe --no-media https://github.com/example/discord-archive.git
 - `--stale-after <duration>` - how stale the local import can get before read commands auto-refresh
 - `--no-auto-update` - disable auto-refresh (use [`update`](update.html) manually)
 - `--no-import` - write config only; skip the initial pull/import
-- `--force` - replace public snapshot tables so the local database exactly matches the snapshot
+- `--exact` - persist exact replacement for this dedicated reader; rows omitted by later snapshots are removed
+- `--force` - replace public snapshot tables for the initial import only; later updates still use the configured update mode
 - `--with-embeddings` - import vectors that match your local `[search.embeddings]` identity
 - `--no-media` - skip restoring cached attachment media files into `cache_dir/media`
 
 ## Disabled in this mode
 
 `sync` and `tail` are disabled when `discord.token_source = "none"` because they need live Discord access. Switch to a token-equipped config to re-enable them.
+
+Use `--exact` for a cache that must expose exactly the publisher's current privacy-filtered view. Do not enable it on a richer local archive: exact updates intentionally remove non-DM rows that are absent from the snapshot. The default merge mode remains appropriate for archives that also ingest Discord or desktop-cache data.
 
 ## After subscribing
 

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -7,7 +7,7 @@ By default, `sync` runs both live/local sources and does **not** import the Git 
 - Discord bot-token sync for bot-visible guild data
 - local Discord Desktop cache import for classifiable cached messages and proven DMs
 
-Use [`update`](update.html) when you want to pull/import the shared Git snapshot. Routine imports upsert changed shards without deleting local cache rows. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` for a stale safe merge or `--update=force` for an exact replacement. `--no-update` is accepted as an explicit no-op alias for the default.
+Use [`update`](update.html) when you want to pull/import the shared Git snapshot. Routine imports upsert changed shards without deleting local cache rows. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` for the configured stale update mode (merge by default) or `--update=force` for an exact replacement. `--no-update` is accepted as an explicit no-op alias for the default.
 
 Run one explicit `--full` pass when you want a complete historical guild archive. Use plain `sync` afterward for frequent latest-message and desktop-cache refreshes.
 
@@ -44,7 +44,7 @@ discrawl sync --with-media
 | Command | Use when | Behavior |
 | --- | --- | --- |
 | `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, only fetches new messages for channels with a stored cursor |
-| `discrawl sync --update=auto` | hybrid Git/live refresh | safely merges a stale Git snapshot first, then runs the routine live refresh |
+| `discrawl sync --update=auto` | hybrid Git/live refresh | applies the configured stale snapshot update mode first, then runs the routine live refresh |
 | `discrawl sync --update=force` | intentional exact reconciliation | replaces public snapshot tables first, then runs the routine live refresh |
 | `discrawl sync --all-channels` | repair pass | broad incremental sweep across every stored channel/thread, including archived threads |
 | `discrawl sync --full` | historical backfill | crawls older history until channels are complete |
@@ -52,7 +52,7 @@ discrawl sync --with-media
 ## Flags
 
 - `--source <both|discord|wiretap>` - which archive sources to read
-- `--update <auto|force|none>` - safe-merge a stale snapshot, force an exact replacement, or skip snapshot import before live deltas
+- `--update <auto|force|none>` - apply the configured stale snapshot update mode, force an exact replacement, or skip snapshot import before live deltas
 - `--full` - historical backfill (slow on large guilds)
 - `--all-channels` - broader incremental sweep across every stored channel/thread
 - `--latest-only` - explicit latest-only run (also the default for untargeted `sync`)

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -2,7 +2,7 @@
 
 Pulls a Git snapshot and safely merges changed rows into the local cache.
 
-Routine imports are delta-planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests. Changed and new shards are upserted without deleting destination-only rows. Discrawl never falls back to an exact replacement unless you pass `--force`.
+Routine imports are delta-planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests. Changed and new shards are upserted without deleting destination-only rows. Discrawl never falls back to an exact replacement unless you pass `--force` or explicitly configure `share.update_mode = "exact"`.
 
 ## Usage
 
@@ -33,13 +33,14 @@ discrawl update --force --ref backup-2026-06-19
 - you set `--no-auto-update` when subscribing and want to refresh on demand
 - a CI job already imported the latest snapshot but read commands still consider it stale
 - you need an exact reconciliation after Discrawl reports removed shards or an incompatible table change (`discrawl update --force`)
+- this is a dedicated filtered-snapshot reader configured with `share.update_mode = "exact"`, so every update must remove rows no longer present upstream
 - you need to restore a named tag or commit while leaving the checked-out share branch untouched (`discrawl update --force --ref <ref>`)
 
-Normal updates preserve rows learned from live Discord or the desktop cache, even when those rows are absent from the Git snapshot. Generated event history and local sync cursors are not replayed during routine merges. If a safe merge is impossible, Discrawl keeps the current database, marks the snapshot as needing attention in `status --json`, and asks you to rerun with `--force`.
+Normal updates preserve rows learned from live Discord or the desktop cache, even when those rows are absent from the Git snapshot. Generated event history and local sync cursors are not replayed during routine merges. If a safe merge is impossible, Discrawl keeps the current database, marks the snapshot as needing attention in `status --json`, and asks you to rerun with `--force`. Exact mode instead replaces public snapshot tables on every update; use it only for a dedicated cache because destination-only non-DM rows are intentionally removed.
 
 ## How `sync` interacts
 
-`discrawl sync` does **not** auto-import the share unless `--update=auto` (safe merge when stale) or `--update=force` (exact replacement before live deltas). Routine live refreshes stay fast; explicit imports happen via `update`.
+`discrawl sync` does **not** auto-import the share unless `--update=auto` (configured update mode when stale) or `--update=force` (exact replacement before live deltas). Routine live refreshes stay fast; explicit imports happen via `update`.
 
 ## See also
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ remote = ""
 repo_path = "~/.local/share/discrawl/share" # macOS: "~/Library/Application Support/discrawl/share"
 branch = "main"
 auto_update = true
+update_mode = "merge" # "exact" for a dedicated snapshot-only cache
 stale_after = "15m"
 media = true
 
@@ -145,6 +146,7 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
 - changing `db_path` does not migrate existing data; copy the file yourself if you want to keep history
 - `sync.attachment_media = true` makes `sync` behave like `sync --with-media`; media bytes are cached under `cache_dir/media`, and CDN `404`/other fetch failures are recorded on attachment rows
 - `share.media = false` makes publish/update/auto-update omit or skip restoring cached media; `subscribe --no-media` writes this for Git-only readers. With the default `share.media = true`, publish/update include cached non-DM media as gzip-compressed snapshot files, but publish does not fetch missing Discord files by itself.
+- `share.update_mode = "merge"` preserves destination-only rows during update and auto-update. Set it to `"exact"` only for a dedicated snapshot reader whose public tables must mirror the current snapshot; exact updates remove non-DM rows that the publisher omits. `subscribe --exact` writes this setting.
 - `[share.filter]` narrows only `publish` output; sync can still keep a richer local archive
 - `share.filter.public_only` exports only channels visible to the guild
   `@everyone` role after category/channel permission overwrites; private

--- a/docs/guides/git-snapshots.md
+++ b/docs/guides/git-snapshots.md
@@ -61,13 +61,14 @@ Once `share.remote` is configured, read commands auto-fetch and import when the 
 ```bash
 discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.git
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git
+discrawl subscribe --exact https://github.com/example/public-archive.git
 ```
 
-`discrawl update` runs the same safe pull/merge step manually. `discrawl update --force --ref <tag-or-commit>` reads historical Git objects directly and leaves the share checkout unchanged. Snapshot imports are delta-planned from crawlkit shard fingerprints. Older manifests without those fields fall back to Git blob identity, so the common publish shape only imports changed canonical shards. Routine merges preserve destination-only rows and do not replay generated event history or remote sync cursors.
+`discrawl update` runs the configured pull/import step manually. The default `share.update_mode = "merge"` is delta-planned from crawlkit shard fingerprints. Older manifests without those fields fall back to Git blob identity, so the common publish shape only imports changed canonical shards. Routine merges preserve destination-only rows and do not replay generated event history or remote sync cursors. `subscribe --exact` persists exact replacement for a dedicated snapshot-only cache, so rows omitted from newer privacy-filtered snapshots are removed during both manual and automatic updates.
 
-Discrawl does not silently fall back to a full import. Removed shards and incompatible table changes leave the current database intact and require `discrawl update --force`. Forced updates replace public snapshot tables and rebuild search indexes; local DM rows remain untouched.
+Discrawl does not silently fall back from merge mode to a full import. Removed shards and incompatible table changes leave the current database intact and require `discrawl update --force`. Forced and configured exact updates replace public snapshot tables and rebuild search indexes; local DM rows remain untouched. Exact mode intentionally removes other destination-only rows, so do not use it on a richer archive that also ingests live Discord or desktop-cache data. `--force` is a one-shot override; `--exact` is the persistent subscription contract.
 
-`discrawl sync` does **not** auto-import the share unless `--update=auto` or `--update=force` is provided. Auto mode uses the safe merge; force mode performs exact replacement before live deltas.
+`discrawl sync` does **not** auto-import the share unless `--update=auto` or `--update=force` is provided. Auto mode uses the configured update mode (merge by default); force mode performs exact replacement before live deltas.
 
 ## Hybrid mode
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -820,7 +820,8 @@ func (r *runtime) autoUpdateShare(mode shareUpdateMode) error {
 		return err
 	}
 	r.setSyncLockPhase("share import")
-	if mode == shareUpdateForce {
+	exact := mode == shareUpdateForce || r.cfg.ShareUpdatesExact()
+	if exact {
 		_, _, err = share.Replace(r.ctx, r.store, opts)
 	} else {
 		_, _, err = share.MergeIfChanged(r.ctx, r.store, opts)
@@ -828,7 +829,7 @@ func (r *runtime) autoUpdateShare(mode shareUpdateMode) error {
 	if errors.Is(err, share.ErrNoManifest) {
 		return nil
 	}
-	if errors.Is(err, share.ErrReplacementRequired) && mode != shareUpdateForce {
+	if errors.Is(err, share.ErrReplacementRequired) && !exact {
 		r.logger.Warn("share update requires forced exact reconciliation", "error", err)
 		return nil
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1279,17 +1279,19 @@ func TestReadCommandsCanDisableAutoImportWithEnv(t *testing.T) {
 	require.Empty(t, lastImport)
 }
 
-func TestSubscribeNoMediaPersistsShareMediaOptOut(t *testing.T) {
+func TestSubscribePersistsExactModeAndMediaOptOut(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
 
 	var out bytes.Buffer
-	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "subscribe", "--no-import", "--no-media", "https://github.com/example/archive.git"}, &out, &bytes.Buffer{}))
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "subscribe", "--no-import", "--exact", "--no-media", "https://github.com/example/archive.git"}, &out, &bytes.Buffer{}))
 
 	cfg, err := config.Load(cfgPath)
 	require.NoError(t, err)
 	require.False(t, cfg.ShareMediaEnabled())
+	require.Equal(t, config.ShareUpdateModeExact, cfg.Share.UpdateMode)
+	require.True(t, cfg.ShareUpdatesExact())
 }
 
 func TestSubscribeCloudDoesNotCreateLocalDB(t *testing.T) {
@@ -2332,6 +2334,18 @@ func TestShareUpdateImportsNewRemoteSnapshot(t *testing.T) {
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "search", "newer snapshot"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "newer git snapshot arrived")
+
+	readerCfg.Share.UpdateMode = config.ShareUpdateModeExact
+	readerCfg.Share.StaleAfter = "1ns"
+	require.NoError(t, config.Write(readerCfgPath, readerCfg))
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "search", "newer snapshot"}, &out, &bytes.Buffer{}))
+	reader, err = store.Open(ctx, readerCfg.DBPath)
+	require.NoError(t, err)
+	_, rows, err = reader.ReadOnlyQuery(ctx, `select count(*) from messages where id = 'local-only'`)
+	require.NoError(t, err)
+	require.Equal(t, "0", rows[0][0], "configured exact auto-update must remove destination-only rows")
+	require.NoError(t, reader.Close())
 
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update", "--force"}, &out, &bytes.Buffer{}))

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -207,7 +207,7 @@ Generate the archive activity report.
 
 Check configuration, storage, credentials, and optional services.
 `,
-	"subscribe": `Usage: discrawl subscribe [--repo PATH] [--branch NAME] [--stale-after DURATION] [--no-auto-update] [--no-import] [--force] [--with-embeddings] [--no-media] REMOTE
+	"subscribe": `Usage: discrawl subscribe [--repo PATH] [--branch NAME] [--stale-after DURATION] [--no-auto-update] [--no-import] [--exact] [--force] [--with-embeddings] [--no-media] REMOTE
 
 Configure and optionally import a read-only snapshot subscription.
 `,

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -172,6 +172,7 @@ func (r *runtime) runSubscribe(args []string) error {
 	staleAfter := fs.String("stale-after", "15m", "")
 	noAutoUpdate := fs.Bool("no-auto-update", false, "")
 	noImport := fs.Bool("no-import", false, "")
+	exact := fs.Bool("exact", false, "")
 	force := fs.Bool("force", false, "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
 	noMedia := fs.Bool("no-media", false, "")
@@ -192,6 +193,10 @@ func (r *runtime) runSubscribe(args []string) error {
 	cfg.Share.Remote = remote
 	cfg.Share.Branch = *branch
 	cfg.Share.AutoUpdate = !*noAutoUpdate
+	cfg.Share.UpdateMode = config.ShareUpdateModeMerge
+	if *exact {
+		cfg.Share.UpdateMode = config.ShareUpdateModeExact
+	}
 	cfg.Share.StaleAfter = *staleAfter
 	if *noMedia {
 		cfg.Share.Media = new(false)
@@ -235,7 +240,7 @@ func (r *runtime) runSubscribe(args []string) error {
 		r.setSyncLockPhase("share import")
 		var manifest share.Manifest
 		var imported bool
-		if *force {
+		if *force || cfg.ShareUpdatesExact() {
 			manifest, imported, err = share.Replace(r.ctx, s, opts)
 		} else {
 			manifest, imported, err = share.MergeIfChanged(r.ctx, s, opts)
@@ -256,6 +261,7 @@ func (r *runtime) runSubscribe(args []string) error {
 			"embeddings":   manifest.Embeddings,
 			"imported":     imported,
 			"forced":       *force,
+			"update_mode":  cfg.Share.UpdateMode,
 		})
 	})
 }
@@ -298,7 +304,8 @@ func (r *runtime) runUpdate(args []string) error {
 			return err
 		}
 		r.setSyncLockPhase("share import")
-		if *force {
+		exact := *force || r.cfg.ShareUpdatesExact()
+		if exact {
 			manifest, imported, err = share.Replace(r.ctx, r.store, opts)
 		} else {
 			manifest, imported, err = share.MergeIfChanged(r.ctx, r.store, opts)
@@ -327,6 +334,7 @@ func (r *runtime) runUpdate(args []string) error {
 		"imported":     imported,
 		"ref":          strings.TrimSpace(*ref),
 		"forced":       *force,
+		"update_mode":  r.cfg.Share.UpdateMode,
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,8 @@ const (
 	DefaultRemoteTokenEnv      = "DISCRAWL_REMOTE_TOKEN"
 	DefaultTokenKeyringService = "discrawl"
 	DefaultTokenKeyringAccount = "discord_bot_token"
+	ShareUpdateModeMerge       = "merge"
+	ShareUpdateModeExact       = "exact"
 )
 
 type Config struct {
@@ -74,6 +76,7 @@ type ShareConfig struct {
 	RepoPath   string            `toml:"repo_path,omitempty"`
 	Branch     string            `toml:"branch,omitempty"`
 	AutoUpdate bool              `toml:"auto_update"`
+	UpdateMode string            `toml:"update_mode"`
 	StaleAfter string            `toml:"stale_after"`
 	Media      *bool             `toml:"media"`
 	Filter     ShareFilterConfig `toml:"filter"`
@@ -166,6 +169,7 @@ func Default() Config {
 			RepoPath:   paths.ShareDir,
 			Branch:     "main",
 			AutoUpdate: true,
+			UpdateMode: ShareUpdateModeMerge,
 			StaleAfter: "15m",
 			Media:      new(true),
 		},
@@ -331,6 +335,13 @@ func (c *Config) Normalize() error {
 	if c.Share.Branch == "" {
 		c.Share.Branch = "main"
 	}
+	c.Share.UpdateMode = strings.ToLower(strings.TrimSpace(c.Share.UpdateMode))
+	if c.Share.UpdateMode == "" {
+		c.Share.UpdateMode = ShareUpdateModeMerge
+	}
+	if c.Share.UpdateMode != ShareUpdateModeMerge && c.Share.UpdateMode != ShareUpdateModeExact {
+		return fmt.Errorf("unsupported share.update_mode %q; use merge or exact", c.Share.UpdateMode)
+	}
 	if c.Share.StaleAfter == "" {
 		c.Share.StaleAfter = "15m"
 	}
@@ -410,6 +421,10 @@ func (c Config) AttachmentMediaEnabled() bool {
 
 func (c Config) ShareMediaEnabled() bool {
 	return c.Share.Media == nil || *c.Share.Media
+}
+
+func (c Config) ShareUpdatesExact() bool {
+	return c.Share.UpdateMode == ShareUpdateModeExact
 }
 
 func (c Config) ShareEnabled() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,8 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.True(t, *cfg.Sync.AttachmentText)
 	require.Equal(t, "fts", cfg.Search.DefaultMode)
 	require.Equal(t, "main", cfg.Share.Branch)
+	require.Equal(t, ShareUpdateModeMerge, cfg.Share.UpdateMode)
+	require.False(t, cfg.ShareUpdatesExact())
 	require.Equal(t, "15m", cfg.Share.StaleAfter)
 	require.Empty(t, cfg.Share.Filter.IncludeChannelIDs)
 	require.Empty(t, cfg.Share.Filter.ExcludeChannelIDs)
@@ -48,6 +50,19 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, 12000, cfg.Search.Embeddings.MaxInputChars)
 	require.Equal(t, "2m", cfg.Search.Embeddings.RequestTimeout)
 	require.Equal(t, "exact", cfg.Search.Embeddings.VectorBackend)
+}
+
+func TestNormalizeShareUpdateMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Share.UpdateMode = " EXACT "
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, ShareUpdateModeExact, cfg.Share.UpdateMode)
+	require.True(t, cfg.ShareUpdatesExact())
+
+	cfg.Share.UpdateMode = "replace-sometimes"
+	require.ErrorContains(t, cfg.Normalize(), "unsupported share.update_mode")
 }
 
 func TestDefaultPathsUseXDGDirs(t *testing.T) {

--- a/internal/share/merge_test.go
+++ b/internal/share/merge_test.go
@@ -132,6 +132,68 @@ func TestMergeIfChangedPreservesLocalRowsUntilForcedReplacement(t *testing.T) {
 	require.Equal(t, "0", rows[0][0], "force must reconcile even when the manifest is unchanged")
 }
 
+func TestExactReplacementRemovesRowsOmittedByNewPublicSnapshot(t *testing.T) {
+	ctx := context.Background()
+	src, err := store.Open(ctx, filepath.Join(t.TempDir(), "src.db"))
+	require.NoError(t, err)
+	defer func() { _ = src.Close() }()
+	require.NoError(t, src.UpsertGuild(ctx, store.GuildRecord{
+		ID:      "g1",
+		Name:    "Guild",
+		RawJSON: `{"roles":[{"id":"g1","permissions":"1024"}]}`,
+	}))
+	channel := store.ChannelRecord{ID: "c-formerly-public", GuildID: "g1", Kind: "text", Name: "formerly-public", RawJSON: `{}`}
+	require.NoError(t, src.UpsertChannel(ctx, channel))
+	upsertSnapshotFilterMessage(t, ctx, src, "m-formerly-public", channel.ID, "u1", "formerly public content")
+	stableChannel := store.ChannelRecord{ID: "c-still-public", GuildID: "g1", Kind: "text", Name: "still-public", RawJSON: `{}`}
+	require.NoError(t, src.UpsertChannel(ctx, stableChannel))
+	upsertSnapshotFilterMessage(t, ctx, src, "m-still-public", stableChannel.ID, "u2", "still public content")
+
+	repo := filepath.Join(t.TempDir(), "share")
+	opts := Options{RepoPath: repo, Branch: "main", Filter: FilterOptions{PublicOnly: true}}
+	first, err := Export(ctx, src, opts)
+	require.NoError(t, err)
+	require.Contains(t, snapshotTableText(t, repo, tableEntry(t, first, "channels")), channel.ID)
+	require.Contains(t, snapshotTableText(t, repo, tableEntry(t, first, "messages")), "m-formerly-public")
+
+	mergeReader, err := store.Open(ctx, filepath.Join(t.TempDir(), "merge-reader.db"))
+	require.NoError(t, err)
+	defer func() { _ = mergeReader.Close() }()
+	exactReader, err := store.Open(ctx, filepath.Join(t.TempDir(), "exact-reader.db"))
+	require.NoError(t, err)
+	defer func() { _ = exactReader.Close() }()
+	_, _, err = MergeIfChanged(ctx, mergeReader, opts)
+	require.NoError(t, err)
+	_, _, err = MergeIfChanged(ctx, exactReader, opts)
+	require.NoError(t, err)
+
+	channel.RawJSON = `{"permission_overwrites":[{"id":"g1","type":0,"deny":"1024"}]}`
+	require.NoError(t, src.UpsertChannel(ctx, channel))
+	second, err := Export(ctx, src, opts)
+	require.NoError(t, err)
+	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, second, "channels")), channel.ID)
+	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, second, "messages")), "m-formerly-public")
+
+	_, changed, err := MergeIfChanged(ctx, mergeReader, opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+	assertSnapshotRows(t, ctx, mergeReader, 1, 1)
+
+	_, changed, err = Replace(ctx, exactReader, opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+	assertSnapshotRows(t, ctx, exactReader, 0, 0)
+}
+
+func assertSnapshotRows(t *testing.T, ctx context.Context, s *store.Store, channels, messages int) {
+	t.Helper()
+	var channelCount, messageCount int
+	require.NoError(t, s.DB().QueryRowContext(ctx, `select count(*) from channels where id = 'c-formerly-public'`).Scan(&channelCount))
+	require.NoError(t, s.DB().QueryRowContext(ctx, `select count(*) from messages where id = 'm-formerly-public'`).Scan(&messageCount))
+	require.Equal(t, channels, channelCount)
+	require.Equal(t, messages, messageCount)
+}
+
 func TestMemberAndGuildTombstonesMergeByRevisionAndRestore(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))


### PR DESCRIPTION
## What

Add a persistent exact snapshot update mode for dedicated readers of privacy-filtered shares.

The existing monotonic merge behavior correctly preserves richer local rows. However, a dedicated reader could retain channels and messages after a newer privacy-filtered snapshot omitted them because their permissions had become private.

## Why

PR #118 intentionally introduced merge-by-default so snapshot updates would not delete rows learned from live Discord or the desktop cache. The existing `--force` flag was deliberately a one-shot exact replacement, and there was no persistent contract for readers that should mirror every new snapshot exactly.

## Fix

- Add `share.update_mode = "merge" | "exact"`, defaulting to `merge`.
- Add `subscribe --exact` to persist exact mode for dedicated snapshot readers.
- Make initial subscription imports, manual updates, auto-updates, and `sync --update=auto` honor the configured mode.
- Keep `--force` as a one-shot exact replacement without changing the persisted mode.
- Do not infer update behavior from `public_only`; filtering and reader reconciliation remain separate choices.

## Proof

- `GOWORK=off go test ./...`
- `make fmt`
- `make lint`
- Source-blind behavior validation: 6/6 clauses passed, covering merge preservation, persistent exact removal, auto-update, one-shot force, invalid configuration, and no Discord access.
- Codex autoreview: clean, with no accepted or actionable findings.
- `git diff --check`

No release was performed.
