### PR TITLE
test: make diagnostics lock failure deterministic

### DIFF
--- a/internal/cli/diagnostics_unix_test.go
+++ b/internal/cli/diagnostics_unix_test.go
@@ -23,8 +23,8 @@ func TestDiagnosticsKeepsUnknownStateWhenLockProbeFails(t *testing.T) {
 	lockPath := filepath.Join(dir, ".discrawl-sync.lock")
 	require.NoError(t, os.WriteFile(lockPath, []byte("locked"), 0o600))
 	writeSyncLockMetadata(t, lockPath, "wiretap", os.Getpid())
-	require.NoError(t, os.Chmod(lockPath, 0))
-	t.Cleanup(func() { _ = os.Chmod(lockPath, 0o600) })
+	require.NoError(t, os.Remove(lockPath))
+	require.NoError(t, os.Symlink(filepath.Base(lockPath), lockPath))
 
 	var out bytes.Buffer
 	require.NoError(t, Run(context.Background(), []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))


### PR DESCRIPTION
## Summary

- Replace the permission-based lock probe failure fixture with a self-referential symlink.
- Running as root can bypass `chmod 000`, while resolving the symlink reliably returns `ELOOP` for both root and non-root users.

## Scope

This changes test setup only. Production behavior is unchanged, so no changelog entry is needed.

## Validation

- Focused test passed 100 consecutive runs.
- `GOWORK=off go test ./...` passed independently.
- Linux/arm64 root proof reproduced the baseline failure; the fixed test passed 20/20 runs.
- `make fmt` and `make lint` passed.
- Source review and secret scanning passed.
