### PR TITLE
chore: open next Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## v0.13.3 - 2026-08-17
 
 ### Fixes


### PR DESCRIPTION
Opens the next Unreleased changelog section after the verified v0.13.3 release.
