### PR TITLE
fix(sync): bootstrap cursorless channels in latest-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Archive the newest page from newly discovered channels and threads during routine syncs while preserving older history for later full backfill.
+
 ## v0.13.3 - 2026-08-17
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Archive the newest page from newly discovered channels and threads during routine syncs while preserving older history for later full backfill.
-
 ## v0.13.3 - 2026-08-17
 
 ### Fixes

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -43,7 +43,7 @@ discrawl sync --with-media
 
 | Command | Use when | Behavior |
 | --- | --- | --- |
-| `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, only fetches new messages for channels with a stored cursor |
+| `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, fetches one newest page when no cursor exists, and otherwise fetches only new messages |
 | `discrawl sync --update=auto` | hybrid Git/live refresh | applies the configured stale snapshot update mode first, then runs the routine live refresh |
 | `discrawl sync --update=force` | intentional exact reconciliation | replaces public snapshot tables first, then runs the routine live refresh |
 | `discrawl sync --all-channels` | repair pass | broad incremental sweep across every stored channel/thread, including archived threads |

--- a/docs/guides/sync-sources.md
+++ b/docs/guides/sync-sources.md
@@ -18,7 +18,7 @@ Sync modes control the Discord bot API side of a run. When `wiretap` is selected
 
 | Command | Use when | Behavior |
 | --- | --- | --- |
-| `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, only fetches new messages for channels with a stored latest cursor |
+| `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, fetches one newest page when no cursor exists, and otherwise fetches only new messages |
 | `discrawl sync --update=auto` | hybrid Git/live refresh | imports a stale Git snapshot first, usually as a changed-shard delta, then runs the routine live refresh |
 | `discrawl sync --all-channels` | repair pass | broad incremental sweep across every stored channel/thread, including archived threads |
 | `discrawl sync --full` | historical backfill | crawls older history until channels are complete; can take a long time on large servers |

--- a/internal/syncer/message_sync.go
+++ b/internal/syncer/message_sync.go
@@ -233,11 +233,16 @@ func (s *Syncer) syncChannelMessages(ctx context.Context, guildID string, channe
 		}
 		return s.syncFullChannelHistory(ctx, channel, state, embeddings, since, progress)
 	}
-	if latestOnly && state.Latest == "" {
+	if shouldSkipChannelSync(channel, state) {
 		return 0, nil
 	}
-	if shouldSkipChannelSync(channel, state) || (latestOnly && shouldSkipLatestOnlyChannelSync(channel, state)) {
-		return 0, nil
+	if latestOnly {
+		if state.Latest == "" {
+			return s.syncLatestChannelHistory(ctx, channel, embeddings, since, progress)
+		}
+		if shouldSkipLatestOnlyChannelSync(channel, state) {
+			return 0, nil
+		}
 	}
 	return s.syncIncrementalChannelHistory(ctx, channel, state, embeddings, since, progress)
 }
@@ -331,7 +336,7 @@ func (s *Syncer) syncFullChannelHistory(ctx context.Context, channel *discordgo.
 		if before == "" && state.Latest != "" {
 			before = state.Latest
 		}
-		count, latest, err := s.syncBackfillPages(ctx, channel, before, newest, channel.Name, embeddings, since, progress)
+		count, latest, err := s.syncBackfillPages(ctx, channel, before, newest, channel.Name, embeddings, since, 0, progress)
 		messageCount += count
 		newest = maxSnowflake(newest, latest)
 		if err != nil {
@@ -350,6 +355,17 @@ func (s *Syncer) syncFullChannelHistory(ctx context.Context, channel *discordgo.
 		}
 	}
 	return messageCount, nil
+}
+
+func (s *Syncer) syncLatestChannelHistory(ctx context.Context, channel *discordgo.Channel, embeddings bool, since time.Time, progress *messageSyncProgress) (int, error) {
+	count, newest, err := s.syncBackfillPages(ctx, channel, "", "", channel.Name, embeddings, since, 1, progress)
+	if err != nil || newest == "" {
+		return count, err
+	}
+	if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
+		return count, err
+	}
+	return count, nil
 }
 
 func (s *Syncer) syncIncrementalChannelHistory(ctx context.Context, channel *discordgo.Channel, state channelSyncState, embeddings bool, since time.Time, progress *messageSyncProgress) (int, error) {
@@ -445,9 +461,10 @@ func (s *Syncer) syncForwardPages(ctx context.Context, channel *discordgo.Channe
 	return messageCount, newest, nil
 }
 
-func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Channel, before, latestFloor, channelName string, embeddings bool, since time.Time, progress *messageSyncProgress) (int, string, error) {
+func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Channel, before, latestFloor, channelName string, embeddings bool, since time.Time, pageLimit int, progress *messageSyncProgress) (int, string, error) {
 	messageCount := 0
 	newest := ""
+	pages := 0
 	for {
 		page, err := s.client.ChannelMessages(ctx, channel.ID, 100, before, "")
 		if err != nil {
@@ -465,6 +482,7 @@ func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Chann
 			return messageCount, newest, err
 		}
 		progress.touch(channel, len(eligible))
+		pages++
 		newest = maxSnowflake(newest, pageNewest)
 		messageCount += len(eligible)
 		// Backfill pages are older than any previously synced head, so only
@@ -494,6 +512,9 @@ func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Chann
 			if err := s.store.SetSyncState(ctx, channelHistoryCompleteScope(channel.ID), "1"); err != nil {
 				return messageCount, newest, err
 			}
+			break
+		}
+		if pageLimit > 0 && pages >= pageLimit {
 			break
 		}
 	}

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -589,7 +590,7 @@ func TestSyncSkipMembersFlagSkipsMemberRefresh(t *testing.T) {
 	require.Zero(t, client.memberCalls)
 }
 
-func TestSyncLatestOnlySkipsChannelsWithoutLatestCursor(t *testing.T) {
+func TestSyncLatestOnlyBootstrapsNewestPageWithoutCompletingHistory(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -597,33 +598,65 @@ func TestSyncLatestOnlySkipsChannelsWithoutLatestCursor(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = s.Close() }()
 
+	messages := make([]*discordgo.Message, 0, 101)
+	for id := 200; id >= 100; id-- {
+		messages = append(messages, &discordgo.Message{
+			ID:        fmt.Sprintf("%03d", id),
+			GuildID:   "g1",
+			ChannelID: "thread",
+			Content:   fmt.Sprintf("message %d", id),
+			Timestamp: time.Now().UTC(),
+			Author:    &discordgo.User{ID: "u1", Username: "user"},
+		})
+	}
 	client := &fakeClient{
 		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
 		guildByID: map[string]*discordgo.Guild{
 			"g1": {ID: "g1", Name: "Guild"},
 		},
 		channels: map[string][]*discordgo.Channel{
-			"g1": {
-				{ID: "c1", GuildID: "g1", Name: "empty", Type: discordgo.ChannelTypeGuildText},
-			},
+			"g1": {{ID: "forum", GuildID: "g1", Name: "development-areas", Type: discordgo.ChannelTypeGuildForum}},
 		},
-		messages: map[string][]*discordgo.Message{
-			"c1": {{
-				ID:        "100",
-				GuildID:   "g1",
-				ChannelID: "c1",
-				Content:   "would bootstrap without latest-only",
-				Timestamp: time.Now().UTC(),
-				Author:    &discordgo.User{ID: "u1", Username: "user"},
+		guildThreads: map[string][]*discordgo.Channel{
+			"g1": {{
+				ID:            "thread",
+				GuildID:       "g1",
+				ParentID:      "forum",
+				Name:          "Beta Feedback",
+				Type:          discordgo.ChannelTypeGuildPublicThread,
+				LastMessageID: "200",
 			}},
 		},
+		messages: map[string][]*discordgo.Message{"thread": messages},
 	}
 
 	svc := New(client, s, nil)
-	stats, err := svc.Sync(ctx, SyncOptions{LatestOnly: true})
+	stats, err := svc.Sync(ctx, SyncOptions{LatestOnly: true, SkipMembers: true})
 	require.NoError(t, err)
-	require.Zero(t, stats.Messages)
-	require.Zero(t, client.messageCalls["c1"])
+	require.Equal(t, 100, stats.Messages)
+	require.Equal(t, 1, client.messageCalls["thread"])
+
+	oldest, newest, err := s.ChannelMessageBounds(ctx, "thread")
+	require.NoError(t, err)
+	require.Equal(t, "101", oldest)
+	require.Equal(t, "200", newest)
+	backfill, err := s.GetSyncState(ctx, channelBackfillScope("thread"))
+	require.NoError(t, err)
+	require.Equal(t, "101", backfill)
+	complete, err := s.GetSyncState(ctx, channelHistoryCompleteScope("thread"))
+	require.NoError(t, err)
+	require.Empty(t, complete)
+
+	stats, err = svc.Sync(ctx, SyncOptions{Full: true, SkipMembers: true})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Messages)
+	oldest, newest, err = s.ChannelMessageBounds(ctx, "thread")
+	require.NoError(t, err)
+	require.Equal(t, "100", oldest)
+	require.Equal(t, "200", newest)
+	complete, err = s.GetSyncState(ctx, channelHistoryCompleteScope("thread"))
+	require.NoError(t, err)
+	require.Equal(t, "1", complete)
 }
 
 func TestSyncLatestOnlySkipsUnchangedIncompleteChannel(t *testing.T) {


### PR DESCRIPTION
## Problem

Routine and scheduled `--latest-only` syncs discover new active channels and threads, but skip their messages forever because those surfaces do not yet have a `latest_message_id` cursor. Channel metadata is published while the message archive remains empty.

## Fix

- Fetch at most one newest page when latest-only sync encounters a cursorless channel.
- Persist the newest message cursor and oldest fetched backfill boundary.
- Leave longer history incomplete so a later `--full` run resumes from that boundary.
- Reuse the canonical backfill loop; no thread-specific behavior.
- Align the routine-sync documentation; leave release-owned changelog curation untouched.

## Real Discord transport proof

Ran this branch with a real Discord bot against a brand-new disposable config and SQLite archive. Guild/channel IDs and credentials are redacted; no message content was inspected or retained.

```text
$ discrawl sync --source discord --guild <redacted> --skip-members --latest-only
message sync started ... channels=6 full=false
message sync finished ... messages_written=261 ... elapsed=2s
{guilds:1, channels:14, threads:0, members:0, messages:261}

$ sqlite3 <disposable-db> <cursor-state-query>
kind=text stored_count=100 latest_cursor=set backfill_cursor=set history_complete=""

$ discrawl sync --source discord --guild <redacted> --channels <redacted> --full --since 2022-01-01T00:00:00Z --skip-members
message sync finished ... messages_written=34 ... elapsed=3s
kind=text stored_count=134 oldest_time=2022-01-17T15:06:21Z latest_cursor=set backfill_cursor=set history_complete=""

$ discrawl sync --source discord --guild <redacted> --channels <redacted> --full --skip-members
message sync finished ... messages_written=3578 ... elapsed=35s
kind=text stored_count=3712 oldest_time=2018-07-21T13:13:45Z latest_cursor=set backfill_cursor=set history_complete=1
```

This proves the production Discord client fetched one bounded head page for a cursorless channel, persisted both cursor boundaries, resumed older history from that boundary, and completed the archive on a later full pass. The disposable archive was deleted afterward.

## Automated proof

- Regression test reproduces an active forum thread with 101 messages. Latest-only stores exactly 100 with one API call; full sync later stores the remaining message and marks history complete.
- `GOWORK=off go test ./...`
- `make lint`
- `make test-race`
- `make test-coverage` (85.1%)
- `make smoke`
- Autoreview: clean, no actionable findings.