### PR TITLE
chore(deps): update Crawlkit to v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Bound release-check HTTP requests to 30 seconds with Crawlkit v0.14.8 so an unresponsive server cannot hang update checks indefinitely.
 - Stop guild and archived-thread pagination with a cursor error when Discord repeats a page instead of hanging sync. Thanks @SebTardif.
 - Reject repeated or missing message-page cursors without losing the last usable backfill checkpoint. Thanks @SebTardif.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,8 @@ stderr notice when a newer Discrawl release is available. Scripted, JSON, CI,
 and non-TTY runs skip the passive notice. Set `DISCRAWL_NO_UPDATE_CHECK=1` or
 `CRAWLKIT_NO_UPDATE_CHECK=1` to disable it.
 
+Release-check HTTP requests time out after 30 seconds if the server does not respond.
+
 ## From source
 
 Requires Go `1.27.0+`.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/openclaw/crawlkit v0.14.7
+	github.com/openclaw/crawlkit v0.14.8
 	github.com/stretchr/testify v1.12.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
-github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
+github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
+github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
Update Crawlkit from v0.14.7 to v0.14.8 so release-check HTTP requests time out after 30 seconds instead of hanging indefinitely. Document that inherited behavior in the changelog and installation guide; no Discrawl application code or CI assertions change.

Dependency audit: `GOWORK=off go get -u -t ./...` and `GOWORK=off go mod tidy` updated Crawlkit and regenerated go.sum. Every direct/indirect requirement in go.mod is now current within its module path. Go 1.27.0, pinned analysis tools, all GitHub Actions references (including CodeQL's action tags), and Docker image digests were already current. The selected module graph also inherits age v1.3.2 from Crawlkit; Discrawl does not import its backup package. No new direct dependencies.

No major upgrade was taken. Defer Bubble Tea v2.0.9, Bubbles v2.2.1, and Lip Gloss v2.0.6: Crawlkit owns the shared TUI and still uses v1. Their v2 migration changes import paths, view types, and key/mouse APIs; migrate Crawlkit upstream first, then consume its release here. [Upstream migration guide](https://github.com/charmbracelet/bubbletea/blob/main/UPGRADE_GUIDE_V2.md).

Validation on Go 1.27.0 / macOS arm64:

- Full build and `GOWORK=off go test -count=1 ./... -coverprofile=.discrawl/deps-refresh-20260830/coverage.out`: pass; aggregate coverage 85.6%, above the unchanged 85% floor.
- `GOWORK=off go test -count=1 -race ./...`: pass for every package.
- `make fmt lint`, `make tidy-check`, `make smoke`, and `actionlint`: pass.
- GoReleaser snapshot: all six darwin/linux/windows × amd64/arm64 archives built; no publication.
- `.agents/skills/autoreview/scripts/autoreview --engine codex --mode local`: clean, no accepted/actionable findings. Reviewer could not fetch upstream source; the timeout was independently verified against the built binary below.

Govulncheck reports zero affected symbols and zero affected imported packages. Its module-only advisory GO-2026-5932 concerns the unused, unmaintained `golang.org/x/crypto/openpgp` package, has no fixed version, and does not affect Discrawl's imported packages.

Live proof used an isolated config with `token_source = "none"`, auto-update disabled, and a synthetic Desktop cache containing one guild message and one DM. These are actual command/output excerpts (paths shortened to a repo-relative shell variable):

```sh
p=.discrawl/deps-refresh-20260830
make build BINARY="$p/discrawl" VERSION=0.13.3
go version -m "$p/discrawl" | rg 'go1.27|crawlkit'
# .discrawl/deps-refresh-20260830/discrawl: go1.27.0
# dep github.com/openclaw/crawlkit v0.14.8

"$p/discrawl" --config "$p/config.toml" --json wiretap --path "$p/desktop"
# "messages": 2, "dm_messages": 1, "guild_messages": 1, "skipped_messages": 0

"$p/discrawl" --config "$p/config.toml" --json search refreshproof
# "content": "refreshproof public fixture checklist"
# "content": "refreshproof private fixture checklist"

"$p/discrawl" --config "$p/config.toml" --json search --dm refreshproof
# "guild_id": "@me", "content": "refreshproof private fixture checklist"

"$p/discrawl" --config "$p/config.toml" --json wiretap --path "$p/desktop"
# "files_unchanged": 1, "messages": 0
"$p/discrawl" --config "$p/config.toml" --json sql 'select count(*) as messages from messages'
# {"columns":["messages"],"rows":[["2"]]}

expect "$p/tui-proof.exp"
# PASS: TUI rendered imported DM: refreshproof private fixture checklist
# TUI q exit=0
```

The terminal script launched `discrawl --config "$p/config.toml" tui --dm`, waited for the imported text, sent `q`, and verified exit 0. No personal archive was read.

For the behavioral change, a loopback HTTP proxy accepted `CONNECT api.github.com:443 HTTP/1.1` and deliberately sent no response:

```sh
HTTPS_PROXY=http://127.0.0.1:62371 NO_PROXY= \
  "$p/discrawl" --config "$p/config.toml" --json check-update --force
# check latest openclaw/discrawl release: Get "https://api.github.com/repos/openclaw/discrawl/releases/latest": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
# exit=1; elapsed=30.10s
```

A separate direct public GitHub lookup returned `github returned 403 Forbidden`; response headers confirmed `x-ratelimit-remaining: 0` for the host's unauthenticated quota. This external check is recorded as blocked, not passing; no credentials or production settings were changed.

CI reasoning: default-branch build/test CI was already green at 1359f06 ([run 33373230652](https://github.com/openclaw/discrawl/actions/runs/33373230652)). The PR's [build/test CI](https://github.com/openclaw/discrawl/actions/runs/33377479684), [Docker build](https://github.com/openclaw/discrawl/actions/runs/33377479676), [CodeQL analysis](https://github.com/openclaw/discrawl/actions/runs/33377479694), and [secret scan](https://github.com/openclaw/discrawl/actions/runs/33377479648) all passed at 328fa03. This PR retains all lint, coverage, race, module-verification, vulnerability, snapshot-build, and secret-scan gates. Docker and CodeQL are additional build/security workflows; backup publication/reports, stale triage, and ClawSweeper dispatch are scheduled or operational workflows, not substitutes for build/test CI. No workflow required a version or policy change.

Prepared for maintainer review; do not auto-merge.
