### PR TITLE
fix(share): preserve local-only data boundaries in shared archives

### DIFF
--- a/.github/workflows/discord-backup-report.yml
+++ b/.github/workflows/discord-backup-report.yml
@@ -72,7 +72,7 @@ jobs:
           printf 'db_path = "%s"\n' "$DB" > "$CONFIG"
           go run ./cmd/discrawl --config "$CONFIG" subscribe --repo "$BACKUP_REPO" "$BACKUP_REMOTE"
           git -C "$BACKUP_REPO" pull --ff-only origin main
-          go run ./cmd/discrawl --config "$CONFIG" report --readme "$BACKUP_REPO/README.md"
+          go run ./cmd/discrawl --config "$CONFIG" report --published --readme "$BACKUP_REPO/README.md"
           if git -C "$BACKUP_REPO" diff --quiet README.md; then
             echo "README already up to date"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Exclude local-only direct messages from published README activity reports and add `report --published` for standalone shared reports, while preserving full local reports and filtered-publication safeguards.
+
 ## 0.14.0 - 2026-09-07
 
 **Highlights:** Search Korean, Japanese, Chinese, and Arabic word forms with optional local language analyzers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Exclude local-only direct messages from published README activity reports and add `report --published` for standalone shared reports, while preserving full local reports and filtered-publication safeguards.
+- Remove generated embedding files from the requested snapshot output when embedding export is disabled, without changing local vectors or unrelated files.
 
 ## 0.14.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep inferred Git fingerprints separate from snapshot integrity metadata when importing legacy snapshots, including historical restores, while preserving incremental merge checkpoints.
 - Exclude local-only direct messages from published README activity reports and add `report --published` for standalone shared reports, while preserving full local reports and filtered-publication safeguards.
 - Remove generated embedding files from the requested snapshot output when embedding export is disabled, without changing local vectors or unrelated files.
 - Validate imported embedding rows against their manifest identity and vector dimensions; reject malformed or non-finite vectors transactionally and skip missing, deleted, and local-only message targets while preserving existing DM vectors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Exclude local-only direct messages from published README activity reports and add `report --published` for standalone shared reports, while preserving full local reports and filtered-publication safeguards.
 - Remove generated embedding files from the requested snapshot output when embedding export is disabled, without changing local vectors or unrelated files.
+- Validate imported embedding rows against their manifest identity and vector dimensions; reject malformed or non-finite vectors transactionally and skip missing, deleted, and local-only message targets while preserving existing DM vectors.
 
 ## 0.14.0 - 2026-09-07
 

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -65,8 +65,9 @@ include_channel_ids = ["1458141495701012561"]
 exclude_channel_ids = []
 ```
 
-`--readme` is disabled when filters are active because the activity report is
-built from the full archive and would otherwise leak unfiltered totals. If the
+`--readme` excludes local-only direct messages, but includes private guild
+channels and threads. It is disabled when filters are active because the report
+does not apply those filters and would otherwise leak unfiltered totals. If the
 share repo already has a generated Discrawl `README.md` from an earlier
 unfiltered publish, filtered publish removes it before committing. Custom
 README files without Discrawl report markers are left alone.

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -83,6 +83,9 @@ README files without Discrawl report markers are left alone.
   (latest update, latest message, totals, day/week/month activity)
 - with `--with-embeddings`: vectors for the configured `[search.embeddings]` provider/model/input version, plus identity manifest
 
+Without `--with-embeddings`, each export removes the generated `embeddings/`
+directory from the requested snapshot output. Local stored vectors are unchanged.
+
 ## What is not published
 
 - `@me` DM guilds, channels, messages, events, attachments, mentions, wiretap sync state

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -6,12 +6,20 @@ Generates the Markdown activity block used by the shared backup repo README.
 
 ```bash
 discrawl report
-discrawl report --readme path/to/discord-backup/README.md
+discrawl report --published --readme path/to/discord-backup/README.md
 ```
 
 ## Flags
 
 - `--readme <path>` - update the activity block in the given README file in place
+- `--published` - exclude local-only direct messages from all statistics and rankings
+
+Local reports include direct messages by default, including with `--readme`.
+Use `--published` for a shared README. Private guild channels and threads remain
+included: this is not a public-only report. This mode excludes direct messages but
+does not implement public-only or channel filters; it refuses configured share
+filters. `publish --readme` selects this mode automatically and continues to
+reject active share filters.
 
 ## What gets rendered
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -201,9 +201,12 @@ Search archived Discord members.
 
 Show archive status and freshness.
 `,
-	"report": `Usage: discrawl report [--readme PATH]
+	"report": `Usage: discrawl report [--published] [--readme PATH]
 
 Generate the archive activity report.
+Local reports include direct messages by default. --published excludes direct
+messages, but still includes private guild content. --published rejects configured
+share filters.
 `,
 	"doctor": `Usage: discrawl doctor [--json]
 

--- a/internal/cli/report_commands.go
+++ b/internal/cli/report_commands.go
@@ -6,19 +6,29 @@ import (
 	"io"
 
 	"github.com/openclaw/discrawl/internal/report"
+	"github.com/openclaw/discrawl/internal/share"
 )
 
 func (r *runtime) runReport(args []string) error {
 	fs := flag.NewFlagSet("report", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	readmePath := fs.String("readme", "", "")
+	published := fs.Bool("published", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("report takes no positional arguments"))
 	}
-	activity, err := report.Build(r.ctx, r.store, report.Options{})
+	filter := share.FilterOptions{
+		PublicOnly:        r.cfg.Share.Filter.PublicOnly,
+		IncludeChannelIDs: r.cfg.Share.Filter.IncludeChannelIDs,
+		ExcludeChannelIDs: r.cfg.Share.Filter.ExcludeChannelIDs,
+	}
+	if *published && filter.Active() {
+		return usageErr(errors.New("report --published is not supported with share filters; filtered report stats would otherwise leak the full archive"))
+	}
+	activity, err := report.Build(r.ctx, r.store, report.Options{Published: *published})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/report_privacy_test.go
+++ b/internal/cli/report_privacy_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishedReportCLIAndPublishExcludeDirectMessages(t *testing.T) {
+	dir := t.TempDir()
+	s := seedCLIStore(t, filepath.Join(dir, "archive.db"))
+	t.Cleanup(func() { _ = s.Close() })
+	require.NoError(t, s.UpsertChannel(t.Context(), store.ChannelRecord{
+		ID: "dm-channel", GuildID: store.DirectMessageGuildID, Name: "dm-only-label", Kind: "dm", RawJSON: `{}`,
+	}))
+	require.NoError(t, s.UpsertMessage(t.Context(), store.MessageRecord{
+		ID: "dm-message", GuildID: store.DirectMessageGuildID, ChannelID: "dm-channel",
+		AuthorID: "dm-author", CreatedAt: "2099-01-01T00:00:00Z",
+		Content: "synthetic direct message", NormalizedContent: "synthetic direct message", RawJSON: `{}`,
+	}))
+	var out bytes.Buffer
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "archive.db")
+	r := &runtime{ctx: t.Context(), cfg: cfg, store: s, stdout: &out, stderr: &bytes.Buffer{}}
+
+	require.NoError(t, r.runReport(nil))
+	require.Contains(t, out.String(), "dm-only-label")
+	require.Contains(t, out.String(), "2099-01-01")
+	out.Reset()
+	require.NoError(t, r.runReport([]string{"--published"}))
+	require.NotContains(t, out.String(), "dm-only-label")
+	require.NotContains(t, out.String(), "2099-01-01")
+	require.Contains(t, out.String(), "general")
+
+	localReadme := filepath.Join(dir, "LOCAL.md")
+	require.NoError(t, r.runReport([]string{"--readme", localReadme}))
+	body, err := os.ReadFile(localReadme)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "dm-only-label")
+	sharedReadme := filepath.Join(dir, "SHARED.md")
+	require.NoError(t, r.runReport([]string{"--published", "--readme", sharedReadme}))
+	body, err = os.ReadFile(sharedReadme)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), "dm-only-label")
+
+	repo := filepath.Join(dir, "share")
+	remote := filepath.Join(dir, "remote.git")
+	runGit(t, dir, "init", "--bare", remote)
+	publishReadme := filepath.Join(repo, "README.md")
+	require.NoError(t, r.runPublish([]string{"--repo", repo, "--remote", remote, "--no-media", "--no-commit", "--readme", publishReadme}))
+	body, err = os.ReadFile(publishReadme)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), "dm-only-label")
+	require.NotContains(t, string(body), "2099-01-01")
+	require.Contains(t, string(body), "general")
+
+	r.cfg.Share.Filter.PublicOnly = true
+	require.NoError(t, r.runReport(nil), "share filters must not change the local default")
+	require.ErrorContains(t, r.runReport([]string{"--published", "--readme", sharedReadme}), "not supported with share filters")
+	require.ErrorContains(t, r.runPublish([]string{"--repo", repo, "--remote", remote, "--no-commit", "--readme", publishReadme}), "not supported with share filters")
+	require.Contains(t, commandUsage["report"], "--published")
+}

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -99,7 +99,7 @@ func (r *runtime) runPublish(args []string) error {
 		}
 	}
 	if *readmePath != "" {
-		activity, err := report.Build(r.ctx, r.store, report.Options{})
+		activity, err := report.Build(r.ctx, r.store, report.Options{Published: true})
 		if err != nil {
 			return err
 		}

--- a/internal/report/published_test.go
+++ b/internal/report/published_test.go
@@ -1,0 +1,87 @@
+package report
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishedReportExcludesDirectMessagesFromEveryStatistic(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	seedReportActivity(t, s, "guild", "private-thread", "guild-author", now.Add(-60*24*time.Hour), 2)
+	opts := Options{Now: now, Published: true}
+	want, err := Build(ctx, s, opts)
+	require.NoError(t, err)
+	require.Equal(t, 2, want.TotalMessages)
+	require.Equal(t, "private-thread", want.TopChannels[0].Name)
+
+	seedReportActivity(t, s, store.DirectMessageGuildID, "dm-channel", "dm-author", now, 12)
+	got, err := Build(ctx, s, opts)
+	require.NoError(t, err)
+	require.Equal(t, want, got, "DM activity must not affect even the window anchor or rankings")
+
+	local, err := Build(ctx, s, Options{Now: now})
+	require.NoError(t, err)
+	explicitFull, err := Build(ctx, s, Options{Now: now, Published: false})
+	require.NoError(t, err)
+	require.Equal(t, local, explicitFull)
+	require.Equal(t, 14, local.TotalMessages)
+	require.Equal(t, 2, local.TotalChannels)
+	require.Equal(t, 2, local.TotalMembers)
+	require.Equal(t, now, local.LatestMessageAt)
+	require.Equal(t, "dm-channel", local.TopChannels[0].Name)
+	require.Equal(t, "dm-author", local.TopAuthors[0].Name)
+	for _, window := range local.Windows {
+		require.Equal(t, 12, window.Messages)
+		require.Equal(t, 12, window.Attachments)
+	}
+	require.Equal(t, RankedCount{Name: "2026-09-01", Count: 12}, local.BusiestDays[0])
+}
+
+func TestPublishedReportWithOnlyDirectMessagesIsEmpty(t *testing.T) {
+	s, err := store.Open(t.Context(), filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	opts := Options{Now: now, Published: true}
+	want, err := Build(t.Context(), s, opts)
+	require.NoError(t, err)
+	seedReportActivity(t, s, store.DirectMessageGuildID, "dm-channel", "dm-author", now.Add(time.Hour), 5)
+	got, err := Build(t.Context(), s, opts)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Zero(t, got.TotalMessages)
+	require.True(t, got.LatestMessageAt.IsZero())
+	local, err := Build(t.Context(), s, Options{Now: now})
+	require.NoError(t, err)
+	require.Equal(t, 5, local.TotalMessages)
+}
+
+func seedReportActivity(t *testing.T, s *store.Store, guild, channel, author string, at time.Time, count int) {
+	t.Helper()
+	ctx := t.Context()
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{ID: guild, Name: guild, RawJSON: `{}`}))
+	require.NoError(t, s.UpsertChannel(ctx, store.ChannelRecord{
+		ID: channel, GuildID: guild, Name: channel, Kind: "private_thread", RawJSON: `{}`,
+	}))
+	require.NoError(t, s.UpsertMember(ctx, store.MemberRecord{
+		GuildID: guild, UserID: author, DisplayName: author, RoleIDsJSON: `[]`, RawJSON: `{}`,
+	}))
+	for i := range count {
+		require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+			ID: fmt.Sprintf("%s-%d", channel, i), GuildID: guild, ChannelID: channel,
+			AuthorID: author, CreatedAt: at.Format(time.RFC3339Nano),
+			Content: "synthetic activity", NormalizedContent: "synthetic activity",
+			HasAttachments: true, RawJSON: `{}`,
+		}))
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -24,6 +24,8 @@ const (
 
 type Options struct {
 	Now time.Time
+	// Published excludes local-only DMs, not private guild content.
+	Published bool
 }
 
 type ActivityReport struct {
@@ -58,7 +60,7 @@ func Build(ctx context.Context, s *store.Store, opts Options) (ActivityReport, e
 		now = time.Now().UTC()
 	}
 	report := ActivityReport{GeneratedAt: now.UTC()}
-	if err := scanTotals(ctx, s.DB(), &report); err != nil {
+	if err := scanTotals(ctx, s.DB(), &report, opts.Published); err != nil {
 		return ActivityReport{}, err
 	}
 	anchor := report.LatestMessageAt
@@ -74,7 +76,7 @@ func Build(ctx context.Context, s *store.Store, opts Options) (ActivityReport, e
 		{"30 days", 30 * 24 * time.Hour},
 	}
 	for _, window := range windows {
-		stats, err := scanWindow(ctx, s.DB(), window.label, anchor.Add(-window.dur))
+		stats, err := scanWindow(ctx, s.DB(), window.label, anchor.Add(-window.dur), opts.Published)
 		if err != nil {
 			return ActivityReport{}, err
 		}
@@ -83,37 +85,40 @@ func Build(ctx context.Context, s *store.Store, opts Options) (ActivityReport, e
 	weekSince := anchor.Add(-7 * 24 * time.Hour)
 	monthSince := anchor.Add(-30 * 24 * time.Hour)
 	var err error
-	report.TopChannels, err = topChannels(ctx, s.DB(), weekSince, 8)
+	report.TopChannels, err = topChannels(ctx, s.DB(), weekSince, 8, opts.Published)
 	if err != nil {
 		return ActivityReport{}, err
 	}
-	report.TopAuthors, err = topAuthors(ctx, s.DB(), weekSince, 8)
+	report.TopAuthors, err = topAuthors(ctx, s.DB(), weekSince, 8, opts.Published)
 	if err != nil {
 		return ActivityReport{}, err
 	}
-	report.BusiestDays, err = busiestDays(ctx, s.DB(), monthSince, 7)
+	report.BusiestDays, err = busiestDays(ctx, s.DB(), monthSince, 7, opts.Published)
 	if err != nil {
 		return ActivityReport{}, err
 	}
 	return report, nil
 }
 
-func scanTotals(ctx context.Context, db *sql.DB, report *ActivityReport) error {
+func scanTotals(ctx context.Context, db *sql.DB, report *ActivityReport, published bool) error {
 	var latest sql.NullString
 	if err := db.QueryRowContext(ctx, `
 		select
-			(select count(*) from messages),
-			(select count(*) from channels),
-			(select count(*) from members),
-			(select created_at from messages order by julianday(created_at) desc, id desc limit 1)
-	`).Scan(&report.TotalMessages, &report.TotalChannels, &report.TotalMembers, &latest); err != nil {
+			(select count(*) from messages where (? = 0 or guild_id <> ?)),
+			(select count(*) from channels where (? = 0 or guild_id <> ?)),
+			(select count(*) from members where (? = 0 or guild_id <> ?)),
+			(select created_at from messages where (? = 0 or guild_id <> ?)
+			 order by julianday(created_at) desc, id desc limit 1)
+	`, published, store.DirectMessageGuildID, published, store.DirectMessageGuildID,
+		published, store.DirectMessageGuildID, published, store.DirectMessageGuildID,
+	).Scan(&report.TotalMessages, &report.TotalChannels, &report.TotalMembers, &latest); err != nil {
 		return fmt.Errorf("scan report totals: %w", err)
 	}
 	report.LatestMessageAt = parseTime(latest.String)
 	return nil
 }
 
-func scanWindow(ctx context.Context, db *sql.DB, label string, since time.Time) (WindowStats, error) {
+func scanWindow(ctx context.Context, db *sql.DB, label string, since time.Time, published bool) (WindowStats, error) {
 	stats := WindowStats{Label: label, Since: since.UTC()}
 	if err := db.QueryRowContext(ctx, `
 		select
@@ -123,25 +128,27 @@ func scanWindow(ctx context.Context, db *sql.DB, label string, since time.Time) 
 			coalesce(sum(case when has_attachments then 1 else 0 end), 0)
 		from messages
 		where julianday(created_at) >= julianday(?)
-	`, reportTimeArg(since)).Scan(&stats.Messages, &stats.ActiveAuthors, &stats.ActiveChannels, &stats.Attachments); err != nil {
+		  and (? = 0 or guild_id <> ?)
+	`, reportTimeArg(since), published, store.DirectMessageGuildID).Scan(&stats.Messages, &stats.ActiveAuthors, &stats.ActiveChannels, &stats.Attachments); err != nil {
 		return WindowStats{}, fmt.Errorf("scan %s stats: %w", label, err)
 	}
 	return stats, nil
 }
 
-func topChannels(ctx context.Context, db *sql.DB, since time.Time, limit int) ([]RankedCount, error) {
+func topChannels(ctx context.Context, db *sql.DB, since time.Time, limit int, published bool) ([]RankedCount, error) {
 	return ranked(ctx, db, `
 		select coalesce(nullif(c.name, ''), m.channel_id) as name, count(*) as total
 		from messages m
 		left join channels c on c.id = m.channel_id
 		where julianday(m.created_at) >= julianday(?)
+		  and (? = 0 or m.guild_id <> ?)
 		group by m.channel_id, coalesce(nullif(c.name, ''), m.channel_id)
 		order by total desc, name asc
 		limit ?
-	`, reportTimeArg(since), limit)
+	`, reportTimeArg(since), published, store.DirectMessageGuildID, limit)
 }
 
-func topAuthors(ctx context.Context, db *sql.DB, since time.Time, limit int) ([]RankedCount, error) {
+func topAuthors(ctx context.Context, db *sql.DB, since time.Time, limit int, published bool) ([]RankedCount, error) {
 	return ranked(ctx, db, `
 		select
 			coalesce(
@@ -158,21 +165,23 @@ func topAuthors(ctx context.Context, db *sql.DB, since time.Time, limit int) ([]
 		from messages m
 		left join members mem on mem.guild_id = m.guild_id and mem.user_id = m.author_id
 		where julianday(m.created_at) >= julianday(?)
+		  and (? = 0 or m.guild_id <> ?)
 		group by m.author_id, name
 		order by total desc, name asc
 		limit ?
-	`, reportTimeArg(since), limit)
+	`, reportTimeArg(since), published, store.DirectMessageGuildID, limit)
 }
 
-func busiestDays(ctx context.Context, db *sql.DB, since time.Time, limit int) ([]RankedCount, error) {
+func busiestDays(ctx context.Context, db *sql.DB, since time.Time, limit int, published bool) ([]RankedCount, error) {
 	return ranked(ctx, db, `
 		select date(created_at) as name, count(*) as total
 		from messages
 		where julianday(created_at) >= julianday(?)
+		  and (? = 0 or guild_id <> ?)
 		group by date(created_at)
 		order by total desc, name desc
 		limit ?
-	`, reportTimeArg(since), limit)
+	`, reportTimeArg(since), published, store.DirectMessageGuildID, limit)
 }
 
 func ranked(ctx context.Context, db *sql.DB, query string, args ...any) ([]RankedCount, error) {

--- a/internal/share/embedding_export_policy_test.go
+++ b/internal/share/embedding_export_policy_test.go
@@ -1,0 +1,82 @@
+package share
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportEmbeddingPolicyTransitions(t *testing.T) {
+	ctx := t.Context()
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	t.Cleanup(func() { _ = src.Close() })
+	seedDirectMessageData(t, ctx, src)
+	require.NoError(t, src.UpsertChannel(ctx, store.ChannelRecord{
+		ID: "c2", GuildID: "g1", Name: "other", Kind: "text", RawJSON: `{}`,
+	}))
+	upsertSnapshotFilterMessage(t, ctx, src, "m2", "c2", "u2", "synthetic second message")
+	blob, err := store.EncodeEmbeddingVector([]float32{1, 0})
+	require.NoError(t, err)
+	for _, model := range []string{"model-a", "model-b"} {
+		for _, id := range []string{"m1", "m2", "dm1"} {
+			_, err := src.DB().ExecContext(ctx, `
+				insert into message_embeddings values (?, 'openai', ?, ?, 2, ?, '2026-09-01T00:00:00Z')
+			`, id, model, store.EmbeddingInputVersion, blob)
+			require.NoError(t, err)
+		}
+	}
+	_, before, err := src.ReadOnlyQuery(ctx, "select * from message_embeddings order by message_id, model")
+	require.NoError(t, err)
+
+	repo := t.TempDir()
+	unrelated := filepath.Join(repo, "notes.txt")
+	require.NoError(t, os.WriteFile(unrelated, []byte("keep unrelated output"), 0o600))
+	opts := Options{
+		RepoPath: repo, Branch: "main", IncludeEmbeddings: true,
+		EmbeddingProvider: "openai", EmbeddingModel: "model-a",
+		EmbeddingInputVersion: store.EmbeddingInputVersion,
+	}
+	check := func(wantModel string, wantRows int) Manifest {
+		t.Helper()
+		manifest, err := Export(ctx, src, opts)
+		require.NoError(t, err)
+		disk := mustReadManifest(t, repo)
+		require.Equal(t, manifest.Embeddings, disk.Embeddings)
+		require.Equal(t, []byte("keep unrelated output"), mustReadFile(t, unrelated))
+		_, after, err := src.ReadOnlyQuery(ctx, "select * from message_embeddings order by message_id, model")
+		require.NoError(t, err)
+		require.Equal(t, before, after, "export must not change any source vector, including DMs")
+		if !opts.IncludeEmbeddings {
+			require.Empty(t, manifest.Embeddings)
+			require.NoDirExists(t, filepath.Join(repo, "embeddings"))
+			return manifest
+		}
+		require.Len(t, manifest.Embeddings, 1)
+		require.Equal(t, wantModel, manifest.Embeddings[0].Model)
+		require.Equal(t, wantRows, manifest.Embeddings[0].Rows)
+		text := snapshotFilesText(t, repo, manifest.Embeddings[0].Files)
+		require.NotContains(t, text, `"message_id":"dm1"`)
+		return manifest
+	}
+	check("model-a", 2)
+	opts.IncludeEmbeddings = false
+	check("", 0)
+	opts.IncludeEmbeddings = true
+	check("model-a", 2)
+	opts.EmbeddingModel = "model-b"
+	check("model-b", 2)
+	require.NoDirExists(t, filepath.Join(repo, "embeddings", "openai", "model-a"))
+	opts.Filter.IncludeChannelIDs = []string{"c1"}
+	narrowed := check("model-b", 1)
+	text := snapshotFilesText(t, repo, narrowed.Embeddings[0].Files)
+	require.Contains(t, text, `"message_id":"m1"`)
+	require.NotContains(t, text, `"message_id":"m2"`)
+	opts.Filter.IncludeChannelIDs = []string{"missing-channel"}
+	empty := check("model-b", 0)
+	require.Empty(t, snapshotFilesText(t, repo, empty.Embeddings[0].Files))
+	opts.IncludeEmbeddings = false
+	check("", 0)
+}

--- a/internal/share/embedding_import_validation_test.go
+++ b/internal/share/embedding_import_validation_test.go
@@ -1,0 +1,203 @@
+package share
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddingImportsPreserveLocalDirectMessageVectors(t *testing.T) {
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	t.Cleanup(func() { _ = src.Close() })
+	seedDeletedEmbeddingMessage(t, src)
+	opts := embeddingValidationOptions(t.TempDir())
+	manifest, err := Export(t.Context(), src, opts)
+	require.NoError(t, err)
+	rows := []map[string]any{
+		embeddingValidationRow(t, "m1", []float32{3, 4}),
+		embeddingValidationRow(t, "dm1", []float32{3, 4}),
+		embeddingValidationRow(t, "deleted-message", []float32{3, 4}),
+		embeddingValidationRow(t, "missing-message", []float32{3, 4}),
+	}
+	writeEmbeddingValidationRows(t, opts, &manifest, rows)
+
+	for _, mode := range []string{"embeddings", "full", "replacement"} {
+		t.Run(mode, func(t *testing.T) {
+			dst := seedStore(t, filepath.Join(t.TempDir(), "dst.db"))
+			t.Cleanup(func() { _ = dst.Close() })
+			seedDirectMessageData(t, t.Context(), dst)
+			seedDeletedEmbeddingMessage(t, dst)
+			for _, id := range []string{"m1", "dm1", "deleted-message"} {
+				seedValidationVector(t, dst, id)
+			}
+			dmBefore := embeddingRowsForMessage(t, dst, "dm1")
+			deletedBefore := embeddingRowsForMessage(t, dst, "deleted-message")
+			require.NoError(t, runValidationImport(t, mode, dst, opts, manifest))
+			require.Equal(t, dmBefore, embeddingRowsForMessage(t, dst, "dm1"), "preexisting local DM vectors must survive full table replacement")
+			require.Equal(t, deletedBefore, embeddingRowsForMessage(t, dst, "deleted-message"))
+			require.Empty(t, embeddingRowsForMessage(t, dst, "missing-message"))
+			var blob []byte
+			require.NoError(t, dst.DB().QueryRowContext(t.Context(), "select embedding_blob from message_embeddings where message_id = 'm1'").Scan(&blob))
+			vector, err := store.DecodeEmbeddingVector(blob)
+			require.NoError(t, err)
+			require.Equal(t, []float32{3, 4}, vector, "canonical nonnumeric message keys remain supported")
+			var dmCount int
+			require.NoError(t, dst.DB().QueryRowContext(t.Context(), "select count(*) from messages where id = 'dm1' and guild_id = ?", store.DirectMessageGuildID).Scan(&dmCount))
+			require.Equal(t, 1, dmCount)
+		})
+	}
+}
+
+func TestMalformedEmbeddingRowsRollBackEntireDestination(t *testing.T) {
+	cases := []struct {
+		name   string
+		field  string
+		value  any
+		errMsg string
+	}{
+		{"provider", "provider", "other", "identity does not match"},
+		{"model", "model", "other", "identity does not match"},
+		{"input version", "input_version", "other", "identity does not match"},
+		{"provider case", "provider", "OPENAI", "identity does not match"},
+		{"blank key", "message_id", " \t", "message_id must not be blank"},
+		{"zero dimensions", "dimensions", 0, "must be positive"},
+		{"negative dimensions", "dimensions", -2, "must be positive"},
+		{"fractional dimensions", "dimensions", 1.5, "decode dimensions"},
+		{"overflow dimensions", "dimensions", json.Number("18446744073709551616"), "decode dimensions"},
+		{"large dimensions", "dimensions", json.Number("4611686018427387906"), "decode"},
+		{"missing dimensions", "dimensions", nil, "decode dimensions"},
+		{"base64", "embedding_blob", "not-base64", "decode embedding blob"},
+		{"unaligned", "embedding_blob", base64.StdEncoding.EncodeToString([]byte{1, 2, 3}), "float32 length"},
+		{"empty vector", "embedding_blob", "", "float32 length"},
+		{"length mismatch", "dimensions", 1, "float32 length"},
+		{"NaN", "embedding_blob", embeddingValidationRow(t, "unused", []float32{float32(math.NaN()), 0})["embedding_blob"], "non-finite"},
+		{"positive infinity", "embedding_blob", embeddingValidationRow(t, "unused", []float32{float32(math.Inf(1)), 0})["embedding_blob"], "non-finite"},
+		{"negative infinity", "embedding_blob", embeddingValidationRow(t, "unused", []float32{float32(math.Inf(-1)), 0})["embedding_blob"], "non-finite"},
+	}
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	t.Cleanup(func() { _ = src.Close() })
+	_, err := src.DB().ExecContext(t.Context(), "update messages set content = 'replacement content' where id = 'm1'")
+	require.NoError(t, err)
+	opts := embeddingValidationOptions(t.TempDir())
+	manifest, err := Export(t.Context(), src, opts)
+	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A valid update precedes each malformed row, including rows whose
+			// target is missing. Validation cannot be bypassed by a target skip.
+			valid := embeddingValidationRow(t, "m1", []float32{3, 4})
+			invalid := embeddingValidationRow(t, "missing-message", []float32{3, 4})
+			invalid[tc.field] = tc.value
+			writeEmbeddingValidationRows(t, opts, &manifest, []map[string]any{valid, invalid})
+			for _, mode := range []string{"embeddings", "full", "replacement"} {
+				t.Run(mode, func(t *testing.T) {
+					dst := seedStore(t, filepath.Join(t.TempDir(), "dst.db"))
+					t.Cleanup(func() { _ = dst.Close() })
+					seedDirectMessageData(t, t.Context(), dst)
+					seedValidationVector(t, dst, "m1")
+					seedValidationVector(t, dst, "dm1")
+					before := validationDatabaseContents(t, dst)
+					require.ErrorContains(t, runValidationImport(t, mode, dst, opts, manifest), tc.errMsg)
+					require.Equal(t, before, validationDatabaseContents(t, dst), "schema, canonical rows, indexes, local vectors and sync state must roll back together")
+				})
+			}
+		})
+	}
+}
+
+func embeddingValidationOptions(repo string) Options {
+	return Options{
+		RepoPath: repo, Branch: "main", IncludeEmbeddings: true,
+		EmbeddingProvider: "openai", EmbeddingModel: "model",
+		EmbeddingInputVersion: store.EmbeddingInputVersion,
+	}
+}
+
+func embeddingValidationRow(t *testing.T, id string, vector []float32) map[string]any {
+	t.Helper()
+	blob, err := store.EncodeEmbeddingVector(vector)
+	require.NoError(t, err)
+	return map[string]any{
+		"message_id": id, "provider": "openai", "model": "model",
+		"input_version": store.EmbeddingInputVersion, "dimensions": len(vector),
+		"embedding_blob": base64.StdEncoding.EncodeToString(blob), "embedded_at": "2026-09-01T00:00:00Z",
+	}
+}
+
+func writeEmbeddingValidationRows(t *testing.T, opts Options, manifest *Manifest, rows []map[string]any) {
+	t.Helper()
+	entry := &manifest.Embeddings[0]
+	entry.Rows = len(rows)
+	var lines []string
+	for _, row := range rows {
+		body, err := json.Marshal(row)
+		require.NoError(t, err)
+		lines = append(lines, string(body))
+	}
+	writeGzipJSONLines(t, filepath.Join(opts.RepoPath, filepath.FromSlash(entry.Files[0])), lines)
+	writeShareManifest(t, opts.RepoPath, *manifest)
+}
+
+func seedValidationVector(t *testing.T, s *store.Store, id string) {
+	t.Helper()
+	blob, err := store.EncodeEmbeddingVector([]float32{1, 2})
+	require.NoError(t, err)
+	_, err = s.DB().ExecContext(t.Context(), `
+		insert into message_embeddings values (?, 'openai', 'model', ?, 2, ?, '2026-08-01T00:00:00Z')
+	`, id, store.EmbeddingInputVersion, blob)
+	require.NoError(t, err)
+}
+
+func seedDeletedEmbeddingMessage(t *testing.T, s *store.Store) {
+	t.Helper()
+	upsertSnapshotFilterMessage(t, t.Context(), s, "deleted-message", "c1", "u1", "synthetic deleted message")
+	_, err := s.DB().ExecContext(t.Context(), "update messages set deleted_at = '2026-09-01T00:00:00Z' where id = 'deleted-message'")
+	require.NoError(t, err)
+}
+
+func embeddingRowsForMessage(t *testing.T, s *store.Store, id string) [][]string {
+	t.Helper()
+	_, rows, err := s.ReadOnlyQuery(t.Context(), "select * from message_embeddings where message_id = '"+id+"' order by provider, model, input_version")
+	require.NoError(t, err)
+	return rows
+}
+
+func runValidationImport(t *testing.T, mode string, dst *store.Store, opts Options, manifest Manifest) error {
+	t.Helper()
+	switch mode {
+	case "embeddings":
+		return ImportEmbeddings(t.Context(), dst, opts, manifest)
+	case "full":
+		_, err := Import(t.Context(), dst, opts)
+		return err
+	case "replacement":
+		_, _, err := Replace(t.Context(), dst, opts)
+		return err
+	default:
+		t.Fatalf("unknown import mode %q", mode)
+		return nil
+	}
+}
+
+func validationDatabaseContents(t *testing.T, s *store.Store) map[string][][]string {
+	t.Helper()
+	_, schema, err := s.ReadOnlyQuery(t.Context(), "select type, name, tbl_name, sql from sqlite_schema order by type, name")
+	require.NoError(t, err)
+	out := map[string][][]string{"schema": schema}
+	for _, entry := range schema {
+		if entry[0] != "table" {
+			continue
+		}
+		_, rows, err := s.ReadOnlyQuery(t.Context(), "select * from "+quoteIdent(entry[1]))
+		require.NoError(t, err)
+		slices.SortFunc(rows, func(a, b []string) int { return slices.Compare(a, b) })
+		out[entry[1]] = rows
+	}
+	return out
+}

--- a/internal/share/embedding_import_validation_test.go
+++ b/internal/share/embedding_import_validation_test.go
@@ -196,7 +196,7 @@ func validationDatabaseContents(t *testing.T, s *store.Store) map[string][][]str
 		}
 		_, rows, err := s.ReadOnlyQuery(t.Context(), "select * from "+quoteIdent(entry[1]))
 		require.NoError(t, err)
-		slices.SortFunc(rows, func(a, b []string) int { return slices.Compare(a, b) })
+		slices.SortFunc(rows, slices.Compare)
 		out[entry[1]] = rows
 	}
 	return out

--- a/internal/share/legacy_manifest_compat_test.go
+++ b/internal/share/legacy_manifest_compat_test.go
@@ -1,0 +1,134 @@
+package share
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrichManifestFromGitPreservesSourceMetadata(t *testing.T) {
+	ctx := t.Context()
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	t.Cleanup(func() { _ = src.Close() })
+	opts := Options{RepoPath: t.TempDir(), Branch: "main"}
+	manifest, err := Export(ctx, src, opts)
+	require.NoError(t, err)
+	configureGitUser(t, opts.RepoPath)
+	_, err = Commit(ctx, opts, "fixture snapshot")
+	require.NoError(t, err)
+	originalBytes := mustReadFile(t, filepath.Join(opts.RepoPath, ManifestName))
+
+	for i := range manifest.Tables {
+		if manifest.Tables[i].Name == "messages" {
+			manifest.Tables[i].FileManifests = nil
+		}
+	}
+	for _, declaredGitHash := range []bool{false, true} {
+		t.Run(map[bool]string{false: "genuine hash", true: "declared git prefix"}[declaredGitHash], func(t *testing.T) {
+			if declaredGitHash {
+				for i := range manifest.Tables {
+					if manifest.Tables[i].Name == "guilds" {
+						manifest.Tables[i].FileManifests[0].SHA256 = "git:declared-in-manifest"
+					}
+				}
+			}
+			before, err := json.Marshal(manifest)
+			require.NoError(t, err)
+			current := snapshotManifest(manifest)
+			enriched := enrichManifestFromGit(ctx, opts.RepoPath, "HEAD", manifest)
+			after, err := json.Marshal(manifest)
+			require.NoError(t, err)
+			require.Equal(t, before, after, "enrichment must not mutate the caller's table slice")
+			require.Empty(t, tableEntry(t, manifest, "messages").FileManifests)
+			for _, table := range current.Tables {
+				if table.Name == "messages" {
+					require.Empty(t, table.FileManifests, "raw Current must remain legacy")
+				}
+			}
+			require.True(t, strings.HasPrefix(tableEntry(t, enriched, "messages").FileManifests[0].SHA256, "git:"))
+			require.Equal(t, tableEntry(t, manifest, "guilds"), tableEntry(t, enriched, "guilds"), "declared modern metadata must remain authoritative, even with a git prefix")
+			require.Equal(t, originalBytes, mustReadFile(t, filepath.Join(opts.RepoPath, ManifestName)))
+		})
+	}
+}
+
+func TestMergeIfChangedMultiShardLegacyAfterHistoricalRestore(t *testing.T) {
+	ctx := t.Context()
+	oldMax := maxShardBytes
+	maxShardBytes = 150
+	t.Cleanup(func() { maxShardBytes = oldMax })
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	t.Cleanup(func() { _ = src.Close() })
+	upsertSnapshotFilterMessage(t, ctx, src, "m2", "c1", "u1", "second legacy message")
+	opts := Options{RepoPath: t.TempDir(), Branch: "main"}
+	publish := func(message string) Manifest {
+		t.Helper()
+		manifest, err := Export(ctx, src, opts)
+		require.NoError(t, err)
+		require.Greater(t, len(tableEntry(t, manifest, "messages").Files), 1)
+		manifest = stripFileManifests(manifest)
+		writeShareManifest(t, opts.RepoPath, manifest)
+		configureGitUser(t, opts.RepoPath)
+		committed, err := Commit(ctx, opts, message)
+		require.NoError(t, err)
+		require.True(t, committed)
+		return manifest
+	}
+	initial := publish("initial legacy snapshot")
+	initialRef := strings.TrimSpace(testGitOutput(t, ctx, opts.RepoPath, "rev-parse", "HEAD"))
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dst.Close() })
+	_, changed, err := MergeIfChanged(ctx, dst, opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 2, legacyMessageCount(t, dst))
+
+	upsertSnapshotFilterMessage(t, ctx, src, "m3", "c1", "u1", "third legacy message")
+	current := publish("updated legacy snapshot")
+	currentRef := strings.TrimSpace(testGitOutput(t, ctx, opts.RepoPath, "rev-parse", "HEAD"))
+	currentBytes := mustReadFile(t, filepath.Join(opts.RepoPath, ManifestName))
+	_, changed, err = MergeIfChanged(ctx, dst, opts)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 3, legacyMessageCount(t, dst))
+
+	historical, err := ImportAt(ctx, dst, opts, initialRef)
+	require.NoError(t, err)
+	require.Equal(t, 2, legacyMessageCount(t, dst))
+	expected := enrichManifestFromGit(ctx, opts.RepoPath, initialRef, initial)
+	require.Equal(t, expected, historical, "checkpoint fingerprints must use the resolved historical commit")
+	previous, ok := PreviousMergedManifest(ctx, dst, opts)
+	require.True(t, ok)
+	imported, ok := PreviousImportedManifest(ctx, dst, opts)
+	require.True(t, ok)
+	wantState, err := json.Marshal(historical)
+	require.NoError(t, err)
+	for _, checkpoint := range []Manifest{previous, imported} {
+		gotState, err := json.Marshal(checkpoint)
+		require.NoError(t, err)
+		require.JSONEq(t, string(wantState), string(gotState))
+	}
+	require.Equal(t, currentRef, strings.TrimSpace(testGitOutput(t, ctx, opts.RepoPath, "rev-parse", "HEAD")))
+	require.Equal(t, currentBytes, mustReadFile(t, filepath.Join(opts.RepoPath, ManifestName)))
+
+	latest, changed, err := MergeIfChanged(ctx, dst, opts)
+	require.NoError(t, err)
+	require.True(t, changed, "historical checkpoint must permit the next legacy merge")
+	require.Equal(t, current.GeneratedAt, latest.GeneratedAt)
+	require.Equal(t, 3, legacyMessageCount(t, dst))
+	_, changed, err = MergeIfChanged(ctx, dst, opts)
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
+func legacyMessageCount(t *testing.T, s *store.Store) int {
+	t.Helper()
+	var count int
+	require.NoError(t, s.DB().QueryRowContext(t.Context(), "select count(*) from messages").Scan(&count))
+	return count
+}

--- a/internal/share/merge.go
+++ b/internal/share/merge.go
@@ -52,6 +52,7 @@ func MergeIfChanged(ctx context.Context, s *store.Store, opts Options) (Manifest
 	if err != nil {
 		return Manifest{}, false, err
 	}
+	current := snapshotManifest(manifest)
 	manifest = enrichManifestFromGit(ctx, opts.RepoPath, "HEAD", manifest)
 	previous, ok := PreviousMergedManifest(ctx, s, opts)
 	allowEventMerge := false
@@ -70,7 +71,7 @@ func MergeIfChanged(ctx context.Context, s *store.Store, opts Options) (Manifest
 		}
 		return Manifest{}, false, err
 	}
-	return importMergePlan(ctx, s, opts, previous, manifest, plan)
+	return importMergePlan(ctx, s, opts, previous, manifest, current, plan)
 }
 
 func shareMergePlan(plan snapshot.ImportPlan, previous snapshot.Manifest, allowEventMerge bool) (snapshot.ImportPlan, error) {

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -477,6 +477,12 @@ func Import(ctx context.Context, s *store.Store, opts Options) (Manifest, error)
 		return Manifest{}, err
 	}
 	manifest = enrichManifestFromGit(ctx, opts.RepoPath, "HEAD", manifest)
+	return importSnapshot(ctx, s, opts, manifest)
+}
+
+// Git fingerprints belong to checkpoint metadata. snapshot.Import reads its
+// integrity metadata from the original manifest under opts.RepoPath.
+func importSnapshot(ctx context.Context, s *store.Store, opts Options, manifest Manifest) (Manifest, error) {
 	opts.reportProgress(ImportProgress{Phase: "start", TotalRows: manifestRowCount(manifest)})
 	restorePragmas, err := applyImportPragmas(ctx, s.DB())
 	if err != nil {
@@ -612,6 +618,7 @@ func importMergePlan(
 	opts Options,
 	previous Manifest,
 	manifest Manifest,
+	current snapshot.Manifest,
 	plan snapshot.ImportPlan,
 ) (Manifest, bool, error) {
 	if !plan.Changed() {
@@ -649,7 +656,7 @@ func importMergePlan(
 		DB:       s.DB(),
 		RootDir:  opts.RepoPath,
 		Previous: snapshotManifest(previous),
-		Current:  snapshotManifest(manifest),
+		Current:  current,
 		Plan:     plan,
 		Progress: func(progress snapshot.ImportProgress) {
 			opts.reportProgress(ImportProgress{
@@ -875,6 +882,8 @@ func enrichManifestFromGit(ctx context.Context, repoPath, rev string, manifest M
 	if err != nil {
 		return manifest
 	}
+	// Enrichment must not change the authoritative on-disk manifest's metadata.
+	manifest.Tables = slices.Clone(manifest.Tables)
 	for i := range manifest.Tables {
 		table := &manifest.Tables[i]
 		if len(table.FileManifests) > 0 {
@@ -983,11 +992,6 @@ func ImportAt(ctx context.Context, s *store.Store, opts Options, ref string) (Ma
 		return Manifest{}, err
 	}
 	manifest = enrichManifestFromGit(ctx, opts.RepoPath, commit, manifest)
-	manifestBody, err = json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		return Manifest{}, fmt.Errorf("marshal historical manifest: %w", err)
-	}
-	manifestBody = append(manifestBody, '\n')
 	tempDir, err := os.MkdirTemp("", "discrawl-share-ref-*")
 	if err != nil {
 		return Manifest{}, fmt.Errorf("create historical share directory: %w", err)
@@ -1024,7 +1028,7 @@ func ImportAt(ctx context.Context, s *store.Store, opts Options, ref string) (Ma
 	historicalOpts.RepoPath = tempDir
 	historicalOpts.Remote = ""
 	historicalOpts.Tag = ""
-	return Import(ctx, s, historicalOpts)
+	return importSnapshot(ctx, s, historicalOpts, manifest)
 }
 
 func tableSnapshotFiles(table TableManifest) []string {

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -13,6 +13,7 @@ import (
 	"hash/fnv"
 	"io"
 	"maps"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -2268,7 +2269,11 @@ func importEmbeddings(ctx context.Context, tx *sql.Tx, opts Options, manifests [
 	stmt, err := tx.PrepareContext(ctx, `
 		insert into message_embeddings(
 			message_id, provider, model, input_version, dimensions, embedding_blob, embedded_at
-		) values(?, ?, ?, ?, ?, ?, ?)
+		) select ?, ?, ?, ?, ?, ?, ?
+		where exists (
+			select 1 from messages
+			where id = ? and guild_id <> ? and deleted_at is null
+		)
 		on conflict(message_id, provider, model, input_version) do update set
 			dimensions = excluded.dimensions,
 			embedding_blob = excluded.embedding_blob,
@@ -2293,7 +2298,7 @@ func importEmbeddings(ctx context.Context, tx *sql.Tx, opts Options, manifests [
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			if err := importEmbeddingFile(ctx, stmt, opts.RepoPath, rel); err != nil {
+			if err := importEmbeddingFile(ctx, stmt, opts.RepoPath, rel, manifest); err != nil {
 				return err
 			}
 		}
@@ -2301,7 +2306,7 @@ func importEmbeddings(ctx context.Context, tx *sql.Tx, opts Options, manifests [
 	return nil
 }
 
-func importEmbeddingFile(ctx context.Context, stmt *sql.Stmt, repoPath, rel string) error {
+func importEmbeddingFile(ctx context.Context, stmt *sql.Stmt, repoPath, rel string, manifest EmbeddingManifest) error {
 	path, err := embeddingRepoPath(repoPath, rel)
 	if err != nil {
 		return err
@@ -2349,11 +2354,35 @@ func importEmbeddingFile(ctx context.Context, stmt *sql.Stmt, repoPath, rel stri
 		if err != nil {
 			return fmt.Errorf("decode dimensions in %s: %w", rel, err)
 		}
+		if dimensions <= 0 {
+			return fmt.Errorf("decode dimensions in %s: must be positive", rel)
+		}
 		blob, err := base64.StdEncoding.DecodeString(row.EmbeddingBlob)
 		if err != nil {
 			return fmt.Errorf("decode embedding blob in %s: %w", rel, err)
 		}
-		if _, err := stmt.ExecContext(ctx, row.MessageID, row.Provider, row.Model, row.InputVersion, dimensions, blob, row.EmbeddedAt); err != nil {
+		if len(blob)%4 != 0 || len(blob)/4 != dimensions {
+			return fmt.Errorf("decode embedding blob in %s: float32 length does not match dimensions", rel)
+		}
+		values, err := store.DecodeEmbeddingVector(blob)
+		if err != nil {
+			return fmt.Errorf("decode embedding blob in %s: %w", rel, err)
+		}
+		for _, value := range values {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				return fmt.Errorf("decode embedding blob in %s: non-finite value", rel)
+			}
+		}
+		if strings.TrimSpace(row.MessageID) == "" {
+			return fmt.Errorf("decode embedding row in %s: message_id must not be blank", rel)
+		}
+		if row.Provider != manifest.Provider || row.Model != manifest.Model || row.InputVersion != manifest.InputVersion {
+			return fmt.Errorf("decode embedding row in %s: identity does not match manifest", rel)
+		}
+		// Older bundles can reference missing, deleted, or local-only messages.
+		// Validate every decoded row, but only update canonical non-DM targets.
+		if _, err := stmt.ExecContext(ctx, row.MessageID, row.Provider, row.Model, row.InputVersion, dimensions, blob, row.EmbeddedAt,
+			row.MessageID, store.DirectMessageGuildID); err != nil {
 			return fmt.Errorf("insert message_embeddings: %w", err)
 		}
 	}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -441,6 +441,10 @@ func Export(ctx context.Context, s *store.Store, opts Options) (Manifest, error)
 			return Manifest{}, err
 		}
 		manifest.Embeddings = []EmbeddingManifest{entry}
+	} else {
+		if err := os.RemoveAll(filepath.Join(opts.RepoPath, "embeddings")); err != nil {
+			return Manifest{}, fmt.Errorf("reset embeddings dir: %w", err)
+		}
 	}
 	if opts.IncludeMedia {
 		entry, err := exportMedia(ctx, s.DB(), opts, filter)

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1528,6 +1528,7 @@ func TestArchiveExportDropsEmbeddingBundleUnlessOptedIn(t *testing.T) {
 	archiveManifest, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.Empty(t, archiveManifest.Embeddings)
+	require.NoDirExists(t, filepath.Join(repo, "embeddings"))
 }
 
 func TestImportEmbeddingsFiltersByConfiguredIdentity(t *testing.T) {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -2453,6 +2453,11 @@ func appendSnapshotRow(t *testing.T, repo string, manifest Manifest, tableName s
 		writeGzipJSONLines(t, full, []string{string(body)})
 		manifest.Tables[i].Files = append(manifest.Tables[i].Files, rel)
 		manifest.Tables[i].Rows++
+		compressed := mustReadFile(t, full)
+		sum := sha256.Sum256(compressed)
+		manifest.Tables[i].FileManifests = append(manifest.Tables[i].FileManifests, snapshot.FileManifest{
+			Path: rel, Rows: 1, Size: int64(len(compressed)), SHA256: hex.EncodeToString(sum[:]),
+		})
 		return manifest
 	}
 	t.Fatalf("table %s not found", tableName)


### PR DESCRIPTION
## What Problem This Solves

Shared archives need to preserve the local-only DM boundary in reports and optional vectors, not just canonical message snapshots. Previously, generated activity reports could include DM names and totals, turning embedding export off could leave generated vectors on disk, and imported embedding rows were not validated against their manifest and canonical message before upsert.

The adapter also synthesized Git-object fingerprints for legacy snapshot planning. Those planning values must not replace the original manifest bytes or be presented as declared SHA256 integrity metadata.

## Why This Change Was Made

- Add `report --published` and use published scope for `publish --readme` and the backup report workflow. All statistics exclude the `@me` DM guild; ordinary local reports are unchanged.
- Remove only the requested snapshot output's generated `embeddings/` directory when embedding export is disabled. Local database vectors and unrelated output files remain untouched.
- Validate embedding identity, positive integer dimensions, float32 byte length, finite values, and nonblank message keys before any upsert. Valid rows targeting missing, deleted, or DM messages are skipped without overwriting existing local vectors.
- Keep legacy Git fingerprints in planning/checkpoint metadata. Full, incremental, and historical imports retain authoritative on-disk manifest metadata; historical imports materialize the original bytes.

Boundaries: `--published` excludes DMs, not private guild channels or threads. Active share filters still reject report generation because filter-aware report statistics are not implemented. No dependency bump, new public hash protocol, live archive cleanup, history rewrite, release, or deployment is included. Current dependency remains CrawlKit `v0.14.9`.

## User Impact

Published activity no longer exposes DM names, counts, or latest-message timestamps. Disabling embedding export removes stale generated vectors from the next requested export. Malformed embedding imports fail atomically; local DM vectors survive full and replacement imports. Legacy snapshots continue to merge and restore when used with stricter CrawlKit integrity validation.

## Evidence

Validation on Linux, Go `go1.27.1`, with `GOWORK=off`, cleared application environment, temporary HOME/XDG directories, and synthetic SQLite/Git fixtures only:

- Original three-fix suite: all 11 tested packages passed; one package had no tests. Full `go vet ./...` passed.
- After the legacy adapter correction, the full published-dependency suite had one failure in a newly added test's nil-versus-empty-slice checkpoint comparison. The assertion was corrected to compare serialized state, then only `./internal/share` was rerun: 67 top-level tests and 77 subtest pass events, two opt-in skips, zero failures. Combined latest root outcomes are 718 passed, eight skipped, zero remaining failures. This does **not** claim the initial full command exited zero.
- Final full vet passed. The two frozen patches received clean independent structured reviews; the original review covered all first-three-commit files, and the later review covered the five-file adapter correction.
- With a temporary modfile pointing to CrawlKit candidate `3148669e82de2dbf5b487ce7436024ae4983843b`, the audited Discrawl head `cce7a940f687aa78ec66ae200e391a5f1628abee` passed all eight selected consumer tests, plus two subtest pass events. A separate temporary overlay verified six rejection/rollback scenarios: actual hash mismatch and declared `git:` hashes through full, incremental, and historical imports. Candidate validation is **not** a released dependency claim; no replacement is committed.
- Current head `37e17383730786ec9fda0f749bde6a37b55b5109` adds only the test-comparator lint fix described below; production, dependency, report, and legacy import code are unchanged. The affected embedding tests were rerun and the one-line correction received a clean independent structured review.

Focused regression commands from the repository root, with HOME and XDG variables directed to disposable directories:

```sh
GOWORK=off go test -count=1 ./internal/report ./internal/cli \
  -run 'Test(PublishedReportExcludesDirectMessagesFromEveryStatistic|PublishedReportWithOnlyDirectMessagesIsEmpty|PublishedReportCLIAndPublishExcludeDirectMessages)$'
GOWORK=off go test -count=1 ./internal/share \
  -run 'Test(ExportEmbeddingPolicyTransitions|EmbeddingImportsPreserveLocalDirectMessageVectors|MalformedEmbeddingRowsRollBackEntireDestination|EnrichManifestFromGitPreservesSourceMetadata|MergeIfChangedMultiShardLegacyAfterHistoricalRestore)$'
GOWORK=off go vet ./...
```

The committed regressions exercise real temporary SQLite stores and generated gzip snapshots. They cover export on/off/model/filter transitions, preservation of source vectors and unrelated output, all 18 malformed row cases across direct/full/replacement import (54 whole-destination rollback comparisons), preservation of existing DM vectors, and legacy multi-shard merge/historical-restore/next-merge continuity.

## Real Behavior Proof

### Executed CLI Report Boundary

**Claim and surface:** the built Discrawl CLI keeps local reporting unchanged while removing DM-derived output from `report --published` and its README activity block.

**Fixture:** a disposable SQLite database with one guild message (`public-message`, `public-guild`, `PublicSentinelChannel`, `PublicSentinelAuthor`, timestamp `2026-09-01T10:00:00Z`) and one newer DM (`dm-message`, guild `@me`, `PrivateSentinelChannel`, `PrivateSentinelAuthor`, timestamp `2026-09-08T11:00:00Z`). Each has one channel, member, and attachment flag. README starts with `# Synthetic Fixture` and `Keep this unrelated line.` The config uses this database, `token_source = "none"`, disabled share auto-update, and disabled embeddings.

**Execution:** September 8, 2026 at 13:16 UTC, Linux, Go `go1.27.1`; isolated HOME/XDG and outbound network syscalls blocked for the child commands. The CLI was built from Discrawl `93a89d0ccccafb0f5902de867112a4c4ee68bb7c` using the temporary candidate CrawlKit modfile. The subsequent adapter-only commit does not change report/CLI code; this earlier binary was not relabeled as a final-head build. In the commands below, `$scratch`, `$modfile`, and config paths stand for disposable fixture paths:

```sh
GOWORK=off go build -modfile="$modfile" -o "$scratch/discrawl" ./cmd/discrawl
"$scratch/discrawl" --config "$scratch/report.toml" report
"$scratch/discrawl" --config "$scratch/report.toml" report --published
"$scratch/discrawl" --config "$scratch/report.toml" report --published \
  --readme "$scratch/README.md"
```

**Observed trace, copied from executed outputs:**

```text
local report: exit 0
Latest archived message: 2026-09-08 11:00 UTC
Archive size: 2 messages, 2 channels, 2 members.
| PrivateSentinelChannel | 1 |
| PrivateSentinelAuthor | 1 |

published report: exit 0
Latest archived message: 2026-09-01 10:00 UTC
Archive size: 1 messages, 1 channels, 1 members.
| PublicSentinelChannel | 1 |
| PublicSentinelAuthor | 1 |

published README update: exit 0
```

All 12 black-box assertions passed: three command exits, local private names/counts/latest timestamp, published exclusion/public names/counts/latest timestamp, README exclusion/unrelated-text preservation/counts, and unchanged database bytes. Before/after fixture SHA256: `f939cb311b66e01d210802fc9fefce9daf7dea577db26c005f8c1ecb24e51430`.

**Limits:** this is a synthetic CLI execution, not a Discord API, hosted backup workflow, or live archive publication. The runtime trace above is report-specific; embedding/legacy import evidence is the executable SQLite/Git integration coverage listed separately, not an invented production run. No real messages, credentials, live stores, or personal fixture paths are included. Optional external tokenizer/vector, large-fixture, Docker, and real-archive integrations were not enabled. The workflow's checkout-built report command has not yet been run against a production backup.

## Review Disposition

The initial CI lint job failed on one test-helper `gocritic/unlambda` diagnostic, not production code: https://github.com/openclaw/discrawl/actions/runs/34234088438/job/102087231356.

Resolved in signed commit `37e17383730786ec9fda0f749bde6a37b55b5109`: use `slices.SortFunc(rows, slices.Compare)` directly instead of wrapping `slices.Compare` in an equivalent closure. No behavior change and no lint suppression.

Affected proof rerun, using isolated temporary HOME/XDG and the published dependency:

```sh
GOWORK=off go test -v -timeout 5m -count=1 ./internal/share \
  -run 'Test(EmbeddingImportsPreserveLocalDirectMessageVectors|MalformedEmbeddingRowsRollBackEntireDestination)$'
```

```text
--- PASS: TestEmbeddingImportsPreserveLocalDirectMessageVectors (0.07s)
--- PASS: TestMalformedEmbeddingRowsRollBackEntireDestination (1.89s)
PASS
ok github.com/openclaw/discrawl/internal/share 1.965s
```

All three DM-vector preservation modes and all 54 malformed-row rollback scenarios passed. The one-line frozen diff received a clean Sol/high structured review (no findings; confidence 0.99). Prior behavioral evidence remains applicable because only the equivalent test comparator changed.

### Maintainer Landing Decision

The initial hosted review at https://github.com/openclaw/discrawl/pull/200#issuecomment-5586269910, reviewed September 8, 2026 at 13:54 UTC, found no code or security defects. Its four remaining checklist items concerned the intended compatibility behavior and coordinated landing decision, not an additional implementation fix.

Under the existing authorization to implement these fixes and merge after their review gates are resolved, the coordinating maintainer has made the following landing decision. This records the delegated decision; it does not claim a separate new user risk sign-off.

- [x] **Resolve embedding compatibility risk:** accept strict, transactional rejection of malformed or identity-mismatched embedding rows as the original intended fix. Recovery is to correct or regenerate the producer's embedding bundle, or import canonical archive data using the existing default without `--with-embeddings`. Omitting embeddings does **not** bypass canonical snapshot/manifest corruption checks. Valid legacy snapshot behavior remains supported.
- [x] **Resolve coordinated landing risk:** the coordinating owner independently verified all four participating changes' substantive review, proof, and CI gates. Public companion changes are https://github.com/openclaw/crawlkit/pull/110 and https://github.com/openclaw/gitcrawl/pull/174; the remaining companion validation was verified privately. No substantive cross-repository coordination hold remains.
- [x] **Complete the requested next step:** the coordinating owner explicitly cleared the coordinated preconditions and accepted the recovery path above under the existing fix/merge authorization.
- [x] **Resolve the maintainer decision:** proceed with the planned strict import validation. A CrawlKit release or dependency rollout is not a condition of merging this source PR: the pinned `v0.14.9` passes CI, while candidate CrawlKit compatibility is readiness evidence for a future published tag, not a claim that it has shipped. No release, dependency bump, or live archive mutation is included.

Final-head CI is successful at https://github.com/openclaw/discrawl/actions/runs/34234335549 for `37e17383730786ec9fda0f749bde6a37b55b5109`: all effective checks passed (15 successful, one optional skipped), including the full suite, full race run, CLI smoke, lint/analyzers, dependency checks, and snapshot release build. Coverage is 85.5%. There are no unresolved line-review threads.

This disposition changes no source or test code and preserves all evidence limits above. A fresh ClawSweeper review is requested against this current main body and unchanged head so the resolved decisions are reflected in the final verdict.

### Review-State Clarification

The updated review at https://github.com/openclaw/discrawl/pull/200#issuecomment-5586269910, reviewed September 8, 2026 at 14:05 UTC, explicitly accepts the maintainer disposition and states that no additional required action remains. Its sole remaining blocking checkbox describes the already accepted compatibility impact. That impact is real and remains documented above: malformed or identity-mismatched embedding bundles fail transactionally, with correction/regeneration or canonical import without embeddings as recovery. This intended, accepted behavior is not an outstanding code change.

Is any concrete unresolved action still required beyond the recorded decision and recovery guidance? If so, please identify it. If none remains, please make the readiness conclusion consistent with the resolved disposition. This clarification does not remove the warning, weaken validation, change proof, or request a particular rating.
