### PR TITLE
fix(ci): bound backup history and record publisher identity

### DIFF
--- a/.github/workflows/discord-backup-report.yml
+++ b/.github/workflows/discord-backup-report.yml
@@ -68,7 +68,9 @@ jobs:
           BACKUP_REMOTE="https://github.com/${DISCRAWL_BACKUP_REPOSITORY}.git"
           mkdir -p "$(dirname "$CONFIG")"
           mkdir -p "$(dirname "$DB")"
-          git clone "$BACKUP_REMOTE" "$BACKUP_REPO"
+          git clone --depth=1 --single-branch --branch main --no-tags \
+            -- "$BACKUP_REMOTE" "$BACKUP_REPO"
+          git -C "$BACKUP_REPO" config --add remote.origin.fetch '^refs/tags/*'
           printf 'db_path = "%s"\n' "$DB" > "$CONFIG"
           go run ./cmd/discrawl --config "$CONFIG" subscribe --repo "$BACKUP_REPO" "$BACKUP_REMOTE"
           git -C "$BACKUP_REPO" pull --ff-only origin main

--- a/.github/workflows/publish-discord-backup.yml
+++ b/.github/workflows/publish-discord-backup.yml
@@ -98,6 +98,15 @@ jobs:
           fi
           go run ./cmd/discrawl --config "$CONFIG" sync "${sync_args[@]}"
           git -C "$BACKUP_REPO" pull --ff-only origin main
+          SOURCE_REVISION="$(git rev-parse HEAD)"
+          if [ "$SOURCE_REVISION" != "$GITHUB_SHA" ]; then
+            echo "::error::Checked-out source revision does not match GITHUB_SHA."
+            exit 1
+          fi
+          DISCRAWL_PRODUCER_REPOSITORY="$GITHUB_REPOSITORY" \
+          DISCRAWL_PRODUCER_REVISION="$SOURCE_REVISION" \
+          DISCRAWL_PRODUCER_RUN_ID="$GITHUB_RUN_ID" \
+          DISCRAWL_PRODUCER_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" \
           go run ./cmd/discrawl --config "$CONFIG" publish \
             --repo "$BACKUP_REPO" \
             --remote "$BACKUP_REMOTE" \

--- a/.github/workflows/publish-discord-backup.yml
+++ b/.github/workflows/publish-discord-backup.yml
@@ -79,7 +79,9 @@ jobs:
           BACKUP_REMOTE="https://github.com/${DISCRAWL_BACKUP_REPOSITORY}.git"
           mkdir -p "$(dirname "$CONFIG")"
           mkdir -p "$(dirname "$DB")"
-          git clone "$BACKUP_REMOTE" "$BACKUP_REPO"
+          git clone --depth=1 --single-branch --branch main --no-tags \
+            -- "$BACKUP_REMOTE" "$BACKUP_REPO"
+          git -C "$BACKUP_REPO" config --add remote.origin.fetch '^refs/tags/*'
           go run ./cmd/discrawl --config "$CONFIG" init --db "$DB" --guild "$DISCRAWL_GUILD_ID"
           if [ -f "$BACKUP_REPO/manifest.json" ]; then
             if [ -s "$DB" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.
+- Provide checked-out source and workflow run identity to Discord archive publications.
 - Keep publication Git arguments bounded with literal NUL-delimited paths and one path-only commit, preserving unrelated staged work.
 - Report incomplete selected channel or category permissions in publication preflight, including inherited thread permissions, without changing public-only export selection.
 - Accept exact manifest-owned table generation paths alongside legacy snapshot shards without broadening publication cleanup or Git staging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.
 - Keep publication Git arguments bounded with literal NUL-delimited paths and one path-only commit, preserving unrelated staged work.
 - Report incomplete selected channel or category permissions in publication preflight, including inherited thread permissions, without changing public-only export selection.
 - Accept exact manifest-owned table generation paths alongside legacy snapshot shards without broadening publication cleanup or Git staging.


### PR DESCRIPTION
## Problem

The disposable backup and report jobs clone the entire archive history.
Using only `--depth=1 --no-tags` is insufficient: the source-built publisher
calls Crawlkit's `SyncForWrite`, which runs `git fetch --prune --tags origin`.
Historical and detached tag ancestry can be fetched back into the shallow clone.

## Changes

- Clone only `main` at depth one with automatic tag following disabled.
- Append `^refs/tags/*` to `remote.origin.fetch` before any Discrawl invocation,
  preserving the positive main-branch refspec.
- Apply the same transport setup to both backup workflows and add a release note.
- Before publication, compare the actual source checkout's `git rev-parse HEAD`
  with `GITHUB_SHA` and fail closed on mismatch.
- Supply source repository/revision and workflow run ID/attempt only to the
  publish command, using the four `DISCRAWL_PRODUCER_*` inputs implemented by
  the separate core candidate in https://github.com/openclaw/discrawl/pull/201.
  The daily report never supplies those inputs or mints a receipt.

This bounds the disposable bootstrap to current main plus descendants needed
during that job. It is not a permanent one-commit limit or a byte cap. Existing
fetch, pull, push, retry, dependency, library, artifact-format, and ordinary
clone behavior are unchanged by the transport fix. There is no history purge
or forced ref update. No receipt schema or application API is implemented here.

## Validation

Settled baseline source: `59ff6b154aa4475d80091615e4654b6a7da0b87e`, Go 1.27.1,
`GOWORK=off`, published Crawlkit v0.14.9.

- Git 2.53.0 and 2.55.0: synthetic `file://` remote with a removed historical blob,
  lightweight and annotated tags, detached tag-only history, and an unrelated
  branch. The shallow/no-tags control acquires tagged objects after the exact
  explicit-tag fetch; the candidate does not. Assertions use object existence,
  not just files or refs.
- Actual built Discrawl CLI: native Git Trace2 records
  `fetch --prune --tags origin` during publication. Cold and warm subscription
  and published-report setup, cold publisher update, remote advancement, and
  successful publication preserve object exclusion and required main ancestry.
- A real pre-push hook advances the synthetic remote with a README change after
  synchronization. The existing non-fast-forward retry preserves that change,
  then publishes successfully without fetching excluded objects.
- A rejecting remote hook keeps the remote unchanged and publication fails,
  including the existing bounded retry. No guard or retry behavior is changed.
- Separate ordinary clone retains historical objects and all tags.
- Five existing focused share tests pass: export/import roundtrip, bare-remote
  pull/push, README-update rebase, bounded literal publication commit, and empty
  selection preserving unrelated staged content.
- Both changed workflows pass actionlint v1.7.7; `git diff --check` passes.
- Local structured reviews of the transport and approved provenance wiring
  report no actionable findings.
- YAML-parsed publisher suffix: matching actual source SHA delivers the exact
  four environment fields only to the publish command; mismatched or unavailable
  source identity stops before invocation. The tuple does not persist after the
  command and the report workflow is unchanged from the transport-only commit.
  This is a shell-wiring test with argument/environment capture, not receipt
  runtime proof.

Both transport runtime matrices pass. Git 2.55.0 was built from the official kernel.org
source tarball in an isolated prefix with static zlib 1.3.1 and Rust/OpenSSL/curl/
gettext/Tcl/Tk/Perl disabled; no claim of an identical hosted-runner build or
tested HTTP transport is made. All runtime transport uses `file://`.
No live archive, private payload download, provider API, or real backup workflow
dispatch was used for this validation.

## Combined Proof And Core Landing

https://github.com/openclaw/discrawl/pull/201 merged on September 9, 2026 at
06:43:26 UTC as `bcd7201dad475706359a255ed99940ce8c22af2a`.
Its tree `2fd3516e683d01e0508a3b33ff8765cd926a9927` is exactly the tested
core candidate `6dda23bf6addf46b16009f2120fe5ffefb4769ad`, including published
Crawlkit v0.15.0, the released-reader compatibility adapter and receipt API.

Both Git 2.53.0 and isolated Git 2.55.0 completed the combined matrix against
that frozen core plus workflow `5013cecc259eca2b466c74fc406139add8ebe922`:

- Actual YAML-extracted publication and report commands execute real
  `go run ./cmd/discrawl` with isolated temporary stores and file transport.
- The actual source-SHA guard rejects mismatches before publication.
- Publication produces a manifest-declared `producer.json` bound to the exact
  manifest bytes. Repository, source revision and synthetic run ID/attempt
  match the expected inputs, including after a real concurrent README push
  triggers receipt-aware atomic push retry.
- Cold/warm daily reports preserve the receipt and its binding without minting
  a new receipt. Rejected delivery leaves the remote receipt unchanged.
- Historical, detached-tag and unrelated-branch objects remain absent after
  publication, report setup, retry and rejection. Native runtime checks cover
  the publisher's actual `fetch --prune --tags origin`.
- The core owner confirms recorded proof with the unmodified released v0.14.0
  reader: unchanged/edit/append generations preserve richer local public/DM
  rows without force; genuine shard removal still refuses. This workflow lane
  did not repeat that owner-run proof.

Evidence-retention qualification: both completed combined result records are
retained. Git 2.53 raw traces remain available; the Git 2.55 raw/derived logs are
now empty, so no independent raw-log re-verification is claimed for that run.
The core owner's original temporary reader fixtures are also no longer retained;
its accepted recorded results and review checkpoint remain available.
The Git 2.55 build/transport qualification above still applies.

Signed normal merge `627012a21be02ba9be50863f256c93042d9cd9cd` incorporates
the landed core without force-pushing. Both changelog entries and all core
release notes are preserved. Exact unchanged workflow blobs:

- Report: `7a334a44ec14f3f50c4d51f6fa3673a7cba1a336`.
- Publisher: `567bd35a7ebaa9e1e5f2ab36e212ce3e7ef6b670`.

All non-workflow files match the landed core except the two approved changelog
additions. Thus the completed combined proof carries forward by exact tree/blob
equivalence; no baseline or full matrix rerun was performed.

## Landing Decision

The coordinator accepts the combined gate and core-first ordering and grants
conditional GO for a guarded squash only after this refreshed head has green
executed CI and actual current-head ClawSweeper clearance with no before-merge
items. Check actual workflow runs and check suites, including `ACTION_REQUIRED`;
an aggregate SUCCESS rollup alone is insufficient. Respect
`@openclaw/openclaw-secops` ownership and applicable repository gates.

No release, production workflow dispatch, live archive mutation, other archive
dataset, backfill, data repair, history purge or forced ref update is authorized.
