### PR TITLE
chore(release): prepare v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.14.1 - 2026-09-09
 
 - Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.
 - Provide checked-out source and workflow run identity to Discord archive publications.


### PR DESCRIPTION
## Summary

Prepare v0.14.1 by changing the top `CHANGELOG.md` heading from
`Unreleased` to `0.14.1 - 2026-09-09`.

This is a one-line metadata change. All 17 existing notes and every older
section remain byte-for-byte unchanged. No application, dependency, workflow,
or release-process changes are included.

## Prerequisites

- Core fixes landed first: https://github.com/openclaw/discrawl/pull/201.
- Workflow fixes landed next: https://github.com/openclaw/discrawl/pull/203.
- Combined main is `a7f41b72f40b701fbbba416f04b5e67c989d8f22`.
- The accepted combined proof and its transport/retention limits are recorded
  at https://github.com/openclaw/discrawl/pull/203#issuecomment-5597439463.
  This metadata change does not add a hosted production-backup proof claim.

## Verification

- Exact one-heading replacement, UTC date, unique version heading, complete
  note preservation, and `git diff --check`: passed.
- All nine jobs in the exact combined-main CI run passed:
  https://github.com/openclaw/discrawl/actions/runs/34320949978.
- Combined-main Docker, CodeQL, secret scanning, and Pages also passed.
- Full application tests were not duplicated locally for unchanged code.
  This PR and the eventual merged release target retain their normal CI gates.

Release publication remains owned exclusively by `release-unified.yml` after
review and exact-main CI. The workflow owns the next empty Unreleased section.
No production backup, live archive, or store operation is part of this PR.
