### PR TITLE
fix: preserve attachment UTF-8 boundaries and safe diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.14.1 - 2026-09-09
 
+- Keep extracted attachment text within its byte limit without splitting valid UTF-8 characters, and identify invalid admitted attachment columns in contents-free export errors without changing stored data or weakening snapshot validation.
 - Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.
 - Provide checked-out source and workflow run identity to Discord archive publications.
 - Update CrawlKit to v0.15.0 while retaining the existing Go minimum and preferred toolchain.

--- a/internal/share/publication_text_diagnostic_test.go
+++ b/internal/share/publication_text_diagnostic_test.go
@@ -1,0 +1,136 @@
+package share
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/crawlkit/snapshot"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicationAttachmentTextDiagnosticPreservesPreviousPublication(t *testing.T) {
+	for _, column := range []string{
+		"attachment_id", "message_id", "guild_id", "channel_id", "author_id",
+		"filename", "content_type", "size", "url", "proxy_url", "text_content",
+		"media_path", "content_sha256", "content_size", "fetched_at",
+		"fetch_status", "fetch_error", "updated_at",
+	} {
+		t.Run(column, func(t *testing.T) {
+			src := seedStore(t, filepath.Join(t.TempDir(), "source.db"))
+			defer func() { _ = src.Close() }()
+			require.NoError(t, addUncachedAttachment(t.Context(), src))
+			opts := Options{RepoPath: filepath.Join(t.TempDir(), "publication"), Producer: fixtureProducer()}
+			_, err := Export(t.Context(), src, opts)
+			require.NoError(t, err)
+			before := publicationBytes(t, opts.RepoPath)
+
+			invalid := "payload-must-not-appear:\xff"
+			_, err = src.DB().ExecContext(t.Context(), "update message_attachments set "+column+" = ?", invalid)
+			require.NoError(t, err)
+			result, err := Export(t.Context(), src, opts)
+			require.EqualError(t, err, "filter table message_attachments: message_attachments."+column+" contains invalid UTF-8")
+			require.Equal(t, Manifest{}, result)
+			require.Equal(t, before, publicationBytes(t, opts.RepoPath))
+			var retained []byte
+			require.NoError(t, src.DB().QueryRowContext(t.Context(),
+				"select cast("+column+" as blob) from message_attachments").Scan(&retained))
+			require.Equal(t, []byte(invalid), retained)
+		})
+	}
+}
+
+func TestPublicationAttachmentBlobStillFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{"invalid-utf8", []byte("payload-not-for-errors:\xff"), "filter table message_attachments: message_attachments.text_content contains invalid UTF-8"},
+		{"valid-utf8", []byte("ordinary blob bytes"), "encode table message_attachments: v1 snapshot cannot safely export BLOB column text_content; filter or explicitly replace its representation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := seedStore(t, filepath.Join(t.TempDir(), "source.db"))
+			defer func() { _ = src.Close() }()
+			require.NoError(t, addUncachedAttachment(t.Context(), src))
+			opts := Options{RepoPath: filepath.Join(t.TempDir(), "publication")}
+			_, err := Export(t.Context(), src, opts)
+			require.NoError(t, err)
+			before := publicationBytes(t, opts.RepoPath)
+			_, err = src.DB().ExecContext(t.Context(), `update message_attachments set text_content = ?`, tc.body)
+			require.NoError(t, err)
+			_, err = Export(t.Context(), src, opts)
+			require.EqualError(t, err, tc.want)
+			require.Equal(t, before, publicationBytes(t, opts.RepoPath))
+			var body []byte
+			var storageClass string
+			require.NoError(t, src.DB().QueryRowContext(t.Context(),
+				`select text_content, typeof(text_content) from message_attachments`).Scan(&body, &storageClass))
+			require.Equal(t, tc.body, body)
+			require.Equal(t, "blob", storageClass)
+		})
+	}
+}
+
+func TestPublicationAttachmentDiagnosticRunsAfterFiltering(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		dm     bool
+		filter FilterOptions
+	}{
+		{"direct-message", true, FilterOptions{}},
+		{"excluded-channel", false, FilterOptions{ExcludeChannelIDs: []string{"c1"}}},
+		{"unselected-channel", false, FilterOptions{IncludeChannelIDs: []string{"other"}}},
+		{"unknown-permissions", false, FilterOptions{PublicOnly: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := seedStore(t, filepath.Join(t.TempDir(), "source.db"))
+			defer func() { _ = src.Close() }()
+			require.NoError(t, addUncachedAttachment(t.Context(), src))
+			guild := "g1"
+			if tc.dm {
+				guild = directMessageGuildID
+			}
+			invalid := "excluded-payload-not-for-errors:\xff"
+			_, err := src.DB().ExecContext(t.Context(),
+				`update message_attachments set text_content = ?, guild_id = ?`, invalid, guild)
+			require.NoError(t, err)
+			result, err := Export(t.Context(), src, Options{
+				RepoPath: filepath.Join(t.TempDir(), "publication"), Filter: tc.filter,
+			})
+			require.NoError(t, err)
+			require.Zero(t, tableEntry(t, result, "message_attachments").Rows)
+			var retained string
+			require.NoError(t, src.DB().QueryRowContext(t.Context(),
+				`select text_content from message_attachments`).Scan(&retained))
+			require.Equal(t, invalid, retained)
+		})
+	}
+}
+
+func TestPublicationAttachmentDiagnosticUsesOnlyFixedSchemaNames(t *testing.T) {
+	row := map[string]any{"untrusted-column-name": "payload-not-for-errors:\xff"}
+	require.NoError(t, validateAttachmentSnapshotText(row))
+	row["text_content"] = "payload-not-for-errors:\xff"
+	require.EqualError(t, validateAttachmentSnapshotText(row), "message_attachments.text_content contains invalid UTF-8")
+}
+
+func TestPublicationTextOutsideAttachmentsKeepsSharedGuard(t *testing.T) {
+	src := seedStore(t, filepath.Join(t.TempDir(), "source.db"))
+	defer func() { _ = src.Close() }()
+	_, err := src.DB().ExecContext(t.Context(), `update messages set content = ?`, "payload-not-for-errors:\xff")
+	require.NoError(t, err)
+	_, err = Export(t.Context(), src, Options{RepoPath: filepath.Join(t.TempDir(), "publication")})
+	require.EqualError(t, err, "encode table messages: snapshot text is not valid UTF-8")
+}
+
+func TestSharedSnapshotStillRejectsInvalidAttachmentText(t *testing.T) {
+	src := seedStore(t, filepath.Join(t.TempDir(), "source.db"))
+	defer func() { _ = src.Close() }()
+	require.NoError(t, addUncachedAttachment(t.Context(), src))
+	_, err := src.DB().ExecContext(t.Context(), `update message_attachments set text_content = ?`, "payload-not-for-errors:\xff")
+	require.NoError(t, err)
+	_, err = snapshot.Export(t.Context(), snapshot.ExportOptions{
+		DB: src.DB(), RootDir: t.TempDir(), Tables: []string{"message_attachments"},
+	})
+	require.EqualError(t, err, "encode table message_attachments: snapshot text is not valid UTF-8")
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/openclaw/crawlkit/mirror"
 	"github.com/openclaw/crawlkit/snapshot"
@@ -465,6 +466,11 @@ func exportPublication(ctx context.Context, s *store.Store, opts Options, before
 			if !filter.allow(table, row) {
 				return false, nil
 			}
+			if table == "message_attachments" {
+				if err := validateAttachmentSnapshotText(row); err != nil {
+					return false, err
+				}
+			}
 			if filter.active && table == "guilds" {
 				if err := projectPublishedGuild(row); err != nil {
 					return false, err
@@ -532,6 +538,22 @@ func exportPublication(ctx context.Context, s *store.Store, opts Options, before
 		return Manifest{}, err
 	}
 	return manifest, nil
+}
+
+func validateAttachmentSnapshotText(row map[string]any) error {
+	// Only fixed public schema names may enter this contents-free diagnostic.
+	// The callback cannot distinguish original TEXT from scanned BLOB values.
+	for _, column := range [...]string{
+		"attachment_id", "message_id", "guild_id", "channel_id", "author_id",
+		"filename", "content_type", "size", "url", "proxy_url", "text_content",
+		"media_path", "content_sha256", "content_size", "fetched_at",
+		"fetch_status", "fetch_error", "updated_at",
+	} {
+		if text, ok := row[column].(string); ok && !utf8.ValidString(text) {
+			return fmt.Errorf("message_attachments.%s contains invalid UTF-8", column)
+		}
+	}
+	return nil
 }
 
 func Import(ctx context.Context, s *store.Store, opts Options) (Manifest, error) {

--- a/internal/syncer/enrichment.go
+++ b/internal/syncer/enrichment.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -258,6 +259,12 @@ func clampText(text string, limit int) string {
 	text = strings.TrimSpace(text)
 	if limit <= 0 || len(text) <= limit {
 		return text
+	}
+	// Keep the byte ceiling without repairing already-invalid source text.
+	if utf8.ValidString(text) {
+		for limit > 0 && !utf8.RuneStart(text[limit]) {
+			limit--
+		}
 	}
 	return strings.TrimSpace(text[:limit])
 }

--- a/internal/syncer/enrichment_test.go
+++ b/internal/syncer/enrichment_test.go
@@ -2,13 +2,21 @@ package syncer
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/share"
+	"github.com/openclaw/discrawl/internal/store"
 )
 
 func TestBuildMessageMutationIncludesAttachmentTextAndMentions(t *testing.T) {
@@ -189,4 +197,125 @@ func TestBuildMessageMutationRespectsAttachmentTextOptOut(t *testing.T) {
 	require.Empty(t, mutation.Attachments[0].TextContent)
 	require.Contains(t, mutation.Record.NormalizedContent, "trace.txt")
 	require.NotContains(t, mutation.Record.NormalizedContent, "stack trace line one")
+}
+
+func TestClampTextUTF8ByteBoundaries(t *testing.T) {
+	for _, character := range []string{"\u00e9", "\u20ac", "\U0001f642", "\ufffd"} {
+		for prefixBytes := attachmentIndexMaxChars - len(character) - 1; prefixBytes <= attachmentIndexMaxChars+1; prefixBytes++ {
+			t.Run(fmt.Sprintf("%U/prefix-%d", []rune(character)[0], prefixBytes), func(t *testing.T) {
+				prefix := strings.Repeat("a", prefixBytes)
+				input := prefix + character + "zzzz"
+				want := prefix
+				switch {
+				case prefixBytes >= attachmentIndexMaxChars:
+					want = strings.Repeat("a", attachmentIndexMaxChars)
+				case prefixBytes+len(character) <= attachmentIndexMaxChars:
+					want += character + strings.Repeat("z", attachmentIndexMaxChars-prefixBytes-len(character))
+				}
+				got := clampText(input, attachmentIndexMaxChars)
+				require.Equal(t, want, got)
+				require.True(t, utf8.ValidString(got))
+				require.LessOrEqual(t, len(got), attachmentIndexMaxChars)
+				require.True(t, strings.HasPrefix(input, got))
+			})
+		}
+	}
+}
+
+func TestClampTextPreservesTrimmingAndInvalidInput(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{"empty", "", 1, ""},
+		{"short", " \tshort\n", 20, "short"},
+		{"ascii", "abcdef", 3, "abc"},
+		{"trim-before-and-after", "  ab  cd  ", 4, "ab"},
+		{"zero-limit", " full text ", 0, "full text"},
+		{"negative-limit", " full text ", -1, "full text"},
+		{"character-exceeds-limit", "\u20ac", 2, ""},
+		{"unicode-whitespace", "\u2003\u00e9\u2003", 2, "\u00e9"},
+		{"valid-replacement", " \ufffd value ", 3, "\ufffd"},
+		{"invalid-short", " bad\xfftext ", 20, "bad\xfftext"},
+		{"invalid-prefix", "bad\xfftext", 4, "bad\xff"},
+		{"invalid-cut", "a\xc3\xa9\xff", 2, "a\xc3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, clampText(tc.input, tc.limit))
+		})
+	}
+}
+
+func TestAttachmentUTF8FetchStorePublicationRoundTrip(t *testing.T) {
+	for _, character := range []string{"\u00e9", "\u20ac", "\U0001f642", "\ufffd"} {
+		t.Run(fmt.Sprintf("%U", []rune(character)[0]), func(t *testing.T) {
+			want := "\ufffd" + strings.Repeat("a", attachmentIndexMaxChars-len("\ufffd")-1)
+			input := " \t" + want + character + " tail\n"
+			mutation := attachmentTextMutation(t, input, "text/plain; charset=utf-8")
+			require.Len(t, mutation.Attachments, 1)
+			require.Equal(t, want, mutation.Attachments[0].TextContent)
+			src, err := store.Open(t.Context(), filepath.Join(t.TempDir(), "source.db"))
+			require.NoError(t, err)
+			defer func() { _ = src.Close() }()
+			require.NoError(t, src.UpsertMessages(t.Context(), []store.MessageMutation{mutation}))
+			var stored string
+			require.NoError(t, src.DB().QueryRowContext(t.Context(),
+				`select text_content from message_attachments where attachment_id = 'attachment'`).Scan(&stored))
+			require.Equal(t, []byte(want), []byte(stored))
+
+			repo := filepath.Join(t.TempDir(), "publication")
+			_, err = share.Export(t.Context(), src, share.Options{RepoPath: repo})
+			require.NoError(t, err)
+			dst, err := store.Open(t.Context(), filepath.Join(t.TempDir(), "destination.db"))
+			require.NoError(t, err)
+			defer func() { _ = dst.Close() }()
+			_, err = share.Import(t.Context(), dst, share.Options{RepoPath: repo})
+			require.NoError(t, err)
+			require.NoError(t, dst.DB().QueryRowContext(t.Context(),
+				`select text_content from message_attachments where attachment_id = 'attachment'`).Scan(&stored))
+			require.Equal(t, []byte(want), []byte(stored))
+		})
+	}
+}
+
+func TestAttachmentFetchDoesNotReplaceInvalidSourceText(t *testing.T) {
+	input := "declared Latin-1 caf\xe9"
+	mutation := attachmentTextMutation(t, input, "text/plain; charset=iso-8859-1")
+	require.Len(t, mutation.Attachments, 1)
+	require.Equal(t, input, mutation.Attachments[0].TextContent)
+	require.False(t, utf8.ValidString(mutation.Attachments[0].TextContent))
+}
+
+type attachmentTextRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f attachmentTextRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func attachmentTextMutation(t *testing.T, text, contentType string) store.MessageMutation {
+	t.Helper()
+	previous := attachmentHTTPClient
+	calls := 0
+	attachmentHTTPClient = &http.Client{Transport: attachmentTextRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}},
+			Body: io.NopCloser(strings.NewReader(text)), ContentLength: int64(len(text)), Request: req,
+		}, nil
+	})}
+	t.Cleanup(func() { attachmentHTTPClient = previous })
+	mutation, err := buildMessageMutation(t.Context(), &discordgo.Message{
+		ID: "message", GuildID: "guild", ChannelID: "channel",
+		Timestamp: time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC),
+		Author:    &discordgo.User{ID: "author", Username: "fixture"},
+		Attachments: []*discordgo.MessageAttachment{{
+			ID: "attachment", Filename: "fixture.txt", ContentType: contentType,
+			URL: "https://example.invalid/fixture.txt", Size: len(text),
+		}},
+	}, "fixture", "", false, true)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	return mutation
 }


### PR DESCRIPTION
## Problem

Attachment extraction applies an 8192-byte text cap. Slicing through a valid
multibyte UTF-8 character can create invalid stored text, which Crawlkit v0.15.0
correctly refuses to export rather than silently replacing bytes.

Other sources of invalid text remain possible. This change does not identify the
field or origin of any existing invalid archive value.

## Changes

- For valid UTF-8 input, end the bounded attachment prefix at a complete character.
  Preserve the existing byte cap and trimming behavior. Existing trimming occurs
  before the limit/length early return and remains unchanged.
- Leave already-invalid input and existing fetch-error handling unchanged.
  Do not decode charsets, insert replacement characters or repair stored text.
- After existing publication filtering admits an attachment row, identify invalid
  strings using only fixed public `message_attachments.column` schema names.
  Return an error without including values, identifiers, URLs, filenames, byte
  samples or claims about the original SQLite storage class.
- Keep Crawlkit v0.15.0, its loss-prevention guards, the schema, importer,
  publication installation and workflows unchanged.

## Validation

- Full affected `internal/syncer` and `internal/share` package suites passed.
- New focused tests and targeted race tests passed; scoped pinned
  golangci-lint v2.13.2 reported zero issues.
- Boundary cases cover two-, three- and four-byte characters, including valid
  replacement characters already present in the input, adjacent/exact limits,
  ASCII, whitespace trimming and existing zero/negative-limit behavior.
- In-memory HTTP responses exercise the real attachment fetch, message mutation
  and store write, followed by actual v0.15.0 publication export/import. Selected
  text survives byte-exactly, including legitimate replacement characters.
- Invalid source text is not replaced or swallowed. Invalid TEXT and BLOB
  fixtures still fail export, and all prior publication files remain unchanged.
- Diagnostics exercise every fixed schema column without disclosing fixture
  contents. Direct-message, excluded, unselected and unknown-permission rows are
  filtered before diagnostics. Other tables retain the shared guard.

All stores, HTTP responses and publications used in tests are synthetic fixtures.
No live archive was read, diagnosed, repaired or backfilled. No backup workflow
was dispatched.

## Landing And Release

Maintainer decision: this narrowly approved prevention/diagnostic fix may land
independently of existing invalid-data repair, after actual current-head CI and
ClawSweeper clearance. Existing invalid archive values still fail closed.
Responsible handling of that known invalid data remains a separate release gate;
this PR does not claim publication recovery or release clearance.

The PR starts as a draft. No release or automated merge is requested.
