### PR TITLE
fix(ci): gate one-time Discord cache repair on verified backup

### DIFF
--- a/.github/workflows/repair-discord-cache.yml
+++ b/.github/workflows/repair-discord-cache.yml
@@ -1,0 +1,652 @@
+name: Backup-first Discord cache repair
+
+on:
+  pull_request:
+    paths: &repair_paths
+      - .github/workflows/repair-discord-cache.yml
+      - scripts/repair_discord_cache.go
+      - scripts/repair_discord_cache_test.go
+      - go.mod
+      - go.sum
+      - internal/store/**
+      - internal/share/**
+      - .github/workflows/publish-discord-backup.yml
+      - .github/workflows/discord-backup-report.yml
+  push:
+    branches: [main]
+    paths: *repair_paths
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Independently reviewed merged main commit
+        required: true
+        type: string
+      cache_identity:
+        description: Approved six-field immutable cache metadata JSON
+        required: true
+        type: string
+      backup_run_id:
+        description: Completed verified backup workflow run
+        required: true
+        type: string
+      backup_run_attempt:
+        description: Verified backup run attempt
+        required: true
+        type: string
+      backup_source_sha:
+        description: Verified backup source commit
+        required: true
+        type: string
+      backup_artifact_id:
+        description: Verified ciphertext artifact ID
+        required: true
+        type: string
+      backup_artifact_digest:
+        description: Verified artifact-container sha256 digest
+        required: true
+        type: string
+      backup_ciphertext_sha256:
+        description: Separately verified ciphertext file sha256
+        required: true
+        type: string
+      root_durable_ack:
+        description: Root confirms retained authenticated decrypt and private original/SQLite readback for this cache
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  GOWORK: "off"
+  GOFLAGS: -mod=readonly
+
+jobs:
+  validate:
+    name: Repair helper synthetic validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Capture trusted test Node
+        id: node
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            if (process.versions.node.split(".")[0] !== "24") core.setFailed("node_runtime");
+            else core.setOutput("binary", process.execPath);
+      - name: Explicit helper tests, race, vet and build
+        env:
+          NODE_BINARY: ${{ steps.node.outputs.binary }}
+        shell: bash
+        run: |
+          test -z "$(gofmt -l scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go)"
+          go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go
+          go test -count=1 -race scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go
+          go vet scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go
+          go build -trimpath -o "$RUNNER_TEMP/repair-discord-cache" scripts/repair_discord_cache.go
+          git diff --exit-code -- go.mod go.sum
+
+  repair:
+    name: Manually acknowledged repair and cache install
+    needs: validate
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.actor == 'vincentkoc' &&
+      github.triggering_actor == 'vincentkoc' &&
+      github.run_attempt == '1' &&
+      inputs.root_durable_ack == true &&
+      needs.validate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+    concurrency:
+      group: discord-backup-repo
+      cancel-in-progress: false
+      queue: max
+    env:
+      DISPATCH_INPUTS: ${{ toJSON(inputs) }}
+      EXPECTED_SHA: ${{ inputs.expected_sha }}
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
+      WORKFLOW_REF: ${{ github.workflow_ref }}
+      TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+    steps:
+      - name: Validate acknowledgement and exact execution context
+        id: context
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            function validateContext(env) {
+              const input = JSON.parse(env.DISPATCH_INPUTS);
+              const fields = ["expected_sha", "cache_identity", "backup_run_id", "backup_run_attempt",
+                "backup_source_sha", "backup_artifact_id", "backup_artifact_digest",
+                "backup_ciphertext_sha256", "root_durable_ack"];
+              const sameKeys = (value, names) => value && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...names].sort());
+              const positive = value => typeof value === "string" && /^[1-9][0-9]*$/.test(value) && Number.isSafeInteger(Number(value));
+              if (!sameKeys(input, fields) || input.root_durable_ack !== true ||
+                  env.GITHUB_REPOSITORY !== "openclaw/discrawl" || env.RUNNER_OS !== "Linux" ||
+                  env.GITHUB_EVENT_NAME !== "workflow_dispatch" || env.GITHUB_REF !== "refs/heads/main" ||
+                  env.GITHUB_RUN_ATTEMPT !== "1" || env.GITHUB_ACTOR !== "vincentkoc" ||
+                  env.TRIGGERING_ACTOR !== "vincentkoc" || !/^[0-9a-f]{40}$/.test(input.expected_sha) ||
+                  env.EXPECTED_SHA !== input.expected_sha || env.GITHUB_SHA !== input.expected_sha ||
+                  env.WORKFLOW_SHA !== input.expected_sha ||
+                  env.WORKFLOW_REF !== "openclaw/discrawl/.github/workflows/repair-discord-cache.yml@refs/heads/main" ||
+                  env.RUNNER_DEBUG === "1" || env.ACTIONS_STEP_DEBUG === "true" || env.ACTIONS_RUNNER_DEBUG === "true" ||
+                  !positive(input.backup_run_id) || !positive(input.backup_run_attempt) || !positive(input.backup_artifact_id) ||
+                  !/^[0-9a-f]{40}$/.test(input.backup_source_sha) ||
+                  !/^sha256:[0-9a-f]{64}$/.test(input.backup_artifact_digest) ||
+                  !/^[0-9a-f]{64}$/.test(input.backup_ciphertext_sha256)) throw new Error();
+              const cache = JSON.parse(input.cache_identity);
+              const cacheFields = ["id", "key", "ref", "version", "created_at", "size_in_bytes"];
+              const version = require("node:crypto").createHash("sha256").update([
+                ".discrawl-ci/discrawl.db", ".discrawl-ci/discrawl.db-shm",
+                ".discrawl-ci/discrawl.db-wal", "zstd-without-long", "1.0"
+              ].join("|")).digest("hex");
+              if (!sameKeys(cache, cacheFields) || !Number.isSafeInteger(cache.id) || cache.id <= 0 ||
+                  !/^discrawl-discord-db-Linux-main-[0-9]+-[0-9]+$/.test(cache.key) ||
+                  cache.ref !== "refs/heads/main" || cache.version !== version ||
+                  !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,9}Z$/.test(cache.created_at) ||
+                  !Number.isSafeInteger(cache.size_in_bytes) || cache.size_in_bytes <= 0 ||
+                  cache.size_in_bytes > 8 * 1024 ** 3) throw new Error();
+              return {input, cache};
+            }
+            try {
+              validateContext(process.env);
+            } catch {
+              core.setFailed("execution_context");
+            }
+
+      - name: Checkout exact reviewed main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.expected_sha }}
+          persist-credentials: false
+      - name: Verify checked-out main
+        shell: bash
+        run: |
+          if [[ "$(git rev-parse HEAD)" != "$EXPECTED_SHA" ]]; then
+            echo "::error::checkout_identity"
+            exit 1
+          fi
+      - name: Checkout unmodified stock cache implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: actions/cache
+          ref: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+          path: .repair-cache-action
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+      - name: Verify restore and save entrypoints before private access
+        id: runtime
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            const fs = require("node:fs"), path = require("node:path"), crypto = require("node:crypto");
+            const {execFileSync} = require("node:child_process");
+            try {
+              const root = path.join(process.env.GITHUB_WORKSPACE, ".repair-cache-action");
+              if (process.platform !== "linux" || process.versions.node.split(".")[0] !== "24" ||
+                  !path.isAbsolute(process.execPath) || !fs.statSync(process.execPath).isFile()) throw new Error();
+              const git = args => execFileSync("git", ["-C", root, ...args], {encoding:"utf8", stdio:["ignore","pipe","pipe"], maxBuffer:8192}).trim();
+              if (git(["rev-parse", "HEAD"]) !== "55cc8345863c7cc4c66a329aec7e433d2d1c52a9" ||
+                  git(["status", "--porcelain", "--untracked-files=all"]) !== "") throw new Error();
+              const verify = (relative, oid, maximum, exact = false) => {
+                const file = path.join(root, relative), info = fs.lstatSync(file);
+                if (!info.isFile() || info.size > maximum || (exact && info.size !== maximum)) throw new Error();
+                const data = fs.readFileSync(file);
+                if (crypto.createHash("sha1").update(`blob ${data.length}\0`).update(data).digest("hex") !== oid ||
+                    git(["rev-parse", "HEAD:" + relative]) !== oid) throw new Error();
+                return data;
+              };
+              verify("dist/restore-only/index.js", "2427fc716c959214d22297fbf24a33c040b968bb", 3377934, true);
+              verify("dist/save-only/index.js", "b3a8aa37f9f7a608d7d5a63a8990b1fd4c043759", 3378478, true);
+              verify("restore/action.yml", "93352f50541fca3b088080dba6b102051220dda2", 8192);
+              verify("save/action.yml", "1b95184507516b6b36a065e21d77e35b3acc4986", 776, true);
+              const pkg = JSON.parse(verify("package.json", "b409614a4fd77b5eb49ee1d36bbf5936dab2792f", 16384));
+              if (pkg.name !== "cache" || pkg.version !== "6.1.0" || pkg.type !== "module" || pkg.engines.node !== ">=24") throw new Error();
+              execFileSync(process.execPath, ["--version"], {env:{PATH:"/usr/bin:/bin"}, stdio:"ignore"});
+              core.setOutput("node_binary", process.execPath);
+            } catch {
+              core.setFailed("cache_runtime");
+            }
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Build and test trusted helper before private restore
+        id: build
+        env:
+          NODE_BINARY: ${{ steps.runtime.outputs.node_binary }}
+        shell: bash
+        run: |
+          umask 077
+          go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go
+          go build -trimpath -o "$RUNNER_TEMP/repair-discord-cache" scripts/repair_discord_cache.go
+          git diff --exit-code -- go.mod go.sum
+          test ! -e .discrawl-ci
+          test ! -L .discrawl-ci
+          command -v zstd >/dev/null
+          [[ "$NODE_BINARY" = /* && -x "$NODE_BINARY" ]]
+          env -i PATH=/usr/bin:/bin "$NODE_BINARY" --version >/dev/null
+          env -i PATH=/usr/bin:/bin DISPATCH_INPUTS="$DISPATCH_INPUTS" "$NODE_BINARY" <<'CAPACITY'
+          try {
+            const cache=JSON.parse(JSON.parse(process.env.DISPATCH_INPUTS).cache_identity);
+            if(!Number.isSafeInteger(cache.size_in_bytes)||cache.size_in_bytes<=0||
+                cache.size_in_bytes>8*1024**3)throw new Error();
+            const space=require("node:fs").statfsSync(".",{bigint:true});
+            const required=BigInt(cache.size_in_bytes)+10n*1024n**3n+8n*1024n**3n;
+            if(space.bsize<=0n||space.bavail<0n||space.bavail*space.bsize<required)throw new Error();
+          }catch{process.stdout.write("::error::restore_capacity\n");process.exitCode=1;}
+          CAPACITY
+          private_temp="$(mktemp -d "$GITHUB_WORKSPACE/.repair-private.XXXXXXXX")"
+          printf 'private_temp=%s\n' "$private_temp" >> "$GITHUB_OUTPUT"
+
+      - name: Validate backup acknowledgement, current main and cache winner
+        id: before
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PHASE: before
+        with:
+          script: &metadata_guards |
+            function timestamp(value) {
+              const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value);
+              if (!match) throw new Error();
+              const seconds = Date.parse(match[1] + "Z");
+              if (!Number.isFinite(seconds) || new Date(seconds).toISOString().slice(0,19) !== match[1]) throw new Error();
+              return BigInt(seconds) * 1000000n + BigInt((match[2] || "").padEnd(9,"0"));
+            }
+            async function requireIdleWriter(github, owner, repo, workflow_id, run) {
+              const waiters=["queued","waiting","pending","requested"];
+              if(waiters.includes(run.status)||run.status==="completed")return;
+              if(run.status!=="in_progress"||!Number.isSafeInteger(run.run_attempt)||run.run_attempt<1||
+                  !/^[0-9a-f]{40}$/.test(run.head_sha))throw new Error();
+              const repair=workflow_id==="repair-discord-cache.yml";
+              const writer=repair?"Manually acknowledged repair and cache install":
+                workflow_id==="publish-discord-backup.yml"?"publish":"report";
+              const validation="Repair helper synthetic validation";
+              const response=await github.rest.actions.listJobsForWorkflowRunAttempt({
+                owner,repo,run_id:run.id,attempt_number:run.run_attempt,per_page:100,page:1
+              });
+              const jobs=response.data.jobs,names=new Set(),ids=new Set();
+              if(!Array.isArray(jobs)||!jobs.length||jobs.length>(repair?2:1)||
+                  response.data.total_count!==jobs.length||(response.headers.link||"").includes('rel="next"'))throw new Error();
+              for(const job of jobs){
+                if(!Number.isSafeInteger(job.id)||job.id<=0||ids.has(job.id)||names.has(job.name)||
+                    job.run_id!==run.id||job.head_sha!==run.head_sha||
+                    (job.run_attempt!==undefined&&job.run_attempt!==run.run_attempt)||
+                    (job.name!==writer&&(!repair||job.name!==validation))||
+                    ![...waiters,"in_progress","completed"].includes(job.status)||
+                    (job.name===writer&&job.status==="in_progress"))throw new Error();
+                ids.add(job.id);names.add(job.name);
+              }
+              // A repair still validating may not have materialized its writer job.
+              if(!names.has(writer)&&(!repair||jobs[0].name!==validation||jobs[0].status==="completed"))throw new Error();
+            }
+            async function metadataGuards(github, env) {
+              const input = JSON.parse(env.DISPATCH_INPUTS), expected = JSON.parse(input.cache_identity);
+              const owner = "openclaw", repo = "discrawl", phase = env.PHASE;
+              const currentRun = Number(env.GITHUB_RUN_ID), newKey = `discrawl-discord-db-Linux-main-${currentRun}-1`;
+              if (!["before","copy","save","after"].includes(phase) || !Number.isSafeInteger(currentRun) ||
+                  env.GITHUB_RUN_ATTEMPT !== "1" || input.root_durable_ack !== true) throw new Error();
+              const main = await github.rest.git.getRef({owner,repo,ref:"heads/main"});
+              if (main.data.object.sha !== input.expected_sha || env.GITHUB_SHA !== input.expected_sha) throw new Error();
+              if (phase === "before") {
+                const run = (await github.rest.actions.getWorkflowRun({owner,repo,run_id:Number(input.backup_run_id)})).data;
+                if (run.repository?.full_name !== "openclaw/discrawl" || run.id !== Number(input.backup_run_id) ||
+                    run.head_sha !== input.backup_source_sha || run.run_attempt !== Number(input.backup_run_attempt) ||
+                    run.status !== "completed" || run.conclusion !== "success" ||
+                    run.path !== ".github/workflows/publish-discord-backup.yml") throw new Error();
+                const artifact = (await github.rest.actions.getArtifact({owner,repo,artifact_id:Number(input.backup_artifact_id)})).data;
+                if (artifact.id !== Number(input.backup_artifact_id) || artifact.workflow_run?.id !== run.id ||
+                    artifact.workflow_run?.head_sha !== run.head_sha || artifact.expired !== false ||
+                    !Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0 ||
+                    artifact.digest !== input.backup_artifact_digest) throw new Error();
+              }
+              const inspected=new Set();
+              for (const workflow_id of ["publish-discord-backup.yml","discord-backup-report.yml","repair-discord-cache.yml"]) {
+                for (const status of ["in_progress","queued","waiting","pending","requested"]) {
+                  const response = await github.rest.actions.listWorkflowRuns({owner,repo,workflow_id,status,per_page:100,
+                    ...(workflow_id==="repair-discord-cache.yml"?{event:"workflow_dispatch"}:{})});
+                  if (response.data.total_count !== response.data.workflow_runs.length ||
+                      (response.headers.link || "").includes('rel="next"')) throw new Error();
+                  for(const run of response.data.workflow_runs){
+                    if(!Number.isSafeInteger(run.id)||run.id<=0)throw new Error();
+                    if(run.id===currentRun)continue;
+                    const identity=`${run.id}:${run.run_attempt}`;
+                    if(run.status==="in_progress"){
+                      if(inspected.has(identity))continue;
+                      if(inspected.size>=100)throw new Error();
+                      inspected.add(identity);
+                    }
+                    await requireIdleWriter(github,owner,repo,workflow_id,run);
+                  }
+                }
+              }
+              const caches = [];
+              let total;
+              for (let page = 1; page <= 10; page++) {
+                const response = await github.rest.actions.getActionsCacheList({
+                  owner,repo,key:"discrawl-discord-db-Linux-main-",ref:"refs/heads/main",
+                  sort:"created_at",direction:"desc",per_page:100,page
+                });
+                if (!Number.isSafeInteger(response.data.total_count) || response.data.total_count > 1000 ||
+                    (total !== undefined && total !== response.data.total_count)) throw new Error();
+                total = response.data.total_count;
+                caches.push(...response.data.actions_caches);
+                if (!(response.headers.link || "").includes('rel="next"')) break;
+                if (page === 10) throw new Error();
+              }
+              if (caches.length !== total || new Set(caches.map(cache => cache.id)).size !== caches.length) throw new Error();
+              const fields = ["id","key","ref","version","created_at","size_in_bytes"];
+              const eligible = caches.filter(cache => cache.ref === "refs/heads/main" && cache.version === expected.version &&
+                typeof cache.key==="string"&&cache.key.startsWith("discrawl-discord-db-Linux-main-"));
+              eligible.sort((a,b) => timestamp(a.created_at) > timestamp(b.created_at) ? -1 : 1);
+              if (!eligible.length || (eligible.length > 1 && timestamp(eligible[0].created_at) === timestamp(eligible[1].created_at))) throw new Error();
+              const source = caches.filter(cache => cache.key === expected.key);
+              if (source.length !== 1 || fields.some(field => source[0][field] !== expected[field])) throw new Error();
+              const saved = caches.filter(cache => cache.key === newKey);
+              if (phase !== "after") {
+                if (saved.length || eligible[0].id !== expected.id) throw new Error();
+                return {key:expected.key,new_key:newKey};
+              }
+              const run = (await github.rest.actions.getWorkflowRun({owner,repo,run_id:currentRun})).data;
+              if (saved.length !== 1 || saved[0].id === expected.id || eligible[0].id !== saved[0].id ||
+                  saved[0].ref !== expected.ref || saved[0].version !== expected.version ||
+                  !Number.isSafeInteger(saved[0].id) || saved[0].id <= 0 ||
+                  !Number.isSafeInteger(saved[0].size_in_bytes) || saved[0].size_in_bytes <= 0 ||
+                  saved[0].size_in_bytes > 8 * 1024 ** 3 ||
+                  timestamp(saved[0].created_at) < timestamp(run.run_started_at) ||
+                  timestamp(saved[0].created_at) > BigInt(Date.now())*1000000n ||
+                  run.head_sha !== input.expected_sha || run.run_attempt !== 1) throw new Error();
+              return {cache:Object.fromEntries(fields.map(field => [field,saved[0][field]])),
+                source_sha:input.expected_sha,run_id:currentRun,run_attempt:1};
+            }
+            try {
+              const result = await metadataGuards(github, process.env);
+              if (process.env.PHASE === "after") core.info(JSON.stringify(result));
+              else {
+                core.setOutput("key", result.key);
+                core.setOutput("new_key", result.new_key);
+              }
+            } catch {
+              if (process.env.PHASE === "after") core.info(JSON.stringify({
+                schema_version:1,status:"installation_unverified",
+                key:`discrawl-discord-db-Linux-main-${process.env.GITHUB_RUN_ID}-1`
+              }));
+              core.setFailed("metadata_gate");
+            }
+
+      - name: Exact lookup with contained stock restore
+        id: lookup
+        timeout-minutes: 2
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PRIVATE_TEMP: ${{ steps.build.outputs.private_temp }}
+          NODE_BINARY: ${{ steps.runtime.outputs.node_binary }}
+          EXPECTED_KEY: ${{ steps.before.outputs.key }}
+          CACHE_MODE: lookup
+        with:
+          script: &contained_cache |
+            async function containedCache(options) {
+              const fs = require("node:fs"), path = require("node:path");
+              const {spawn, execFileSync} = require("node:child_process");
+              const {node,entry,workspace,privateRoot,key,lookupOnly,saveOnly=false,timeoutMs,streamCap=1048576,commandCap=4096} = options;
+              if (!/^discrawl-discord-db-Linux-main-[0-9]+-[0-9]+$/.test(key) ||
+                  !["true","false"].includes(lookupOnly) || typeof saveOnly !== "boolean" ||
+                  (saveOnly && lookupOnly !== "false") || timeoutMs <= 0 || timeoutMs > 570000 ||
+                  streamCap <= 0 || streamCap > 1048576 || commandCap <= 0 || commandCap > 4096) throw new Error("restore_context");
+              const directory = fs.mkdtempSync(path.join(privateRoot,"contained-"));
+              fs.chmodSync(directory,0700);
+              const descriptors=[],commands=[];
+              let child,reason="",streamBytes=0,commandBytes=0,poll,deadline,cleanup,armCleanup;
+              const open = name => {
+                const fd=fs.openSync(path.join(directory,name),"wx",0o600);
+                descriptors.push(fd);
+                return fd;
+              };
+              const stop = failure => {
+                if (!reason) reason=failure;
+                if (child?.pid) {
+                  try { process.kill(-child.pid,"SIGKILL"); }
+                  catch (error) { if (error.code!=="ESRCH") reason="restore_cleanup"; }
+                }
+                armCleanup?.();
+              };
+              const cancelled=()=>stop("restore_cancelled");
+              try {
+                const stdout=open("stdout"),stderr=open("stderr"),env={};
+                for (const name of ["PATH","HOME","TMPDIR","LANG","TZ","CI","RUNNER_OS","RUNNER_ARCH","RUNNER_TEMP","RUNNER_TRACKING_ID",
+                    "GITHUB_ACTIONS","GITHUB_WORKSPACE","GITHUB_REPOSITORY","GITHUB_REF","GITHUB_SHA","GITHUB_RUN_ID","GITHUB_RUN_ATTEMPT",
+                    "GITHUB_SERVER_URL","GITHUB_API_URL","ACTIONS_CACHE_URL","ACTIONS_RESULTS_URL","ACTIONS_RUNTIME_URL",
+                    "ACTIONS_RUNTIME_TOKEN","ACTIONS_CACHE_SERVICE_V2"]) {
+                  if (process.env[name]!==undefined) env[name]=process.env[name];
+                }
+                Object.assign(env,{INPUT_PATH:".discrawl-ci/discrawl.db\n.discrawl-ci/discrawl.db-shm\n.discrawl-ci/discrawl.db-wal",
+                  INPUT_KEY:key,INPUT_ENABLECROSSOSARCHIVE:"false",SEGMENT_DOWNLOAD_TIMEOUT_MINS:"2",
+                  RUNNER_DEBUG:"0",ACTIONS_STEP_DEBUG:"false",ACTIONS_RUNNER_DEBUG:"false"});
+                if (!saveOnly) Object.assign(env,{"INPUT_RESTORE-KEYS":"","INPUT_FAIL-ON-CACHE-MISS":"true","INPUT_LOOKUP-ONLY":lookupOnly});
+                for (const name of ["GITHUB_OUTPUT","GITHUB_ENV","GITHUB_PATH","GITHUB_STATE","GITHUB_STEP_SUMMARY"]) {
+                  const file=path.join(directory,name);
+                  execFileSync("/usr/bin/mkfifo",["-m","600",file],{stdio:"ignore"});
+                  const fd=fs.openSync(file,fs.constants.O_RDWR|fs.constants.O_NONBLOCK);
+                  descriptors.push(fd);
+                  commands.push({name,fd,capture:open(name+".capture"),chunks:[]});
+                  env[name]=file;
+                }
+                const capture=(fd,chunk,command=false)=>{
+                  const used=command?commandBytes:streamBytes,cap=command?commandCap:streamCap;
+                  const accepted=chunk.subarray(0,Math.max(0,cap-used));
+                  if (accepted.length) fs.writeFileSync(fd,accepted);
+                  if (command) commandBytes+=accepted.length; else streamBytes+=accepted.length;
+                  if (accepted.length!==chunk.length) stop("restore_capture_cap");
+                  return accepted;
+                };
+                const drain=()=>{
+                  const buffer=Buffer.alloc(4096);
+                  for (const command of commands) {
+                    for (;;) {
+                      let count;
+                      try { count=fs.readSync(command.fd,buffer,0,buffer.length,null); }
+                      catch(error) { if(error.code==="EAGAIN") break; throw error; }
+                      if(!count) break;
+                      command.chunks.push(Buffer.from(capture(command.capture,buffer.subarray(0,count),true)));
+                      if(command.name!=="GITHUB_OUTPUT") stop("restore_commands");
+                      if(reason) break;
+                    }
+                  }
+                };
+                process.once("SIGTERM",cancelled); process.once("SIGINT",cancelled);
+                const result=await new Promise(resolve=>{
+                  let settled=false;
+                  const finish=result=>{if(!settled){settled=true;resolve(result);}};
+                  armCleanup=()=>{
+                    if(cleanup) return;
+                    cleanup=setTimeout(()=>{
+                      reason="restore_cleanup";child.stdout.destroy();child.stderr.destroy();child.unref();
+                      finish({code:null,signal:"SIGKILL"});
+                    },2000);
+                  };
+                  child=spawn(node,[entry],{cwd:workspace,env,detached:true,stdio:["ignore","pipe","pipe"]});
+                  const onData=fd=>chunk=>{try{capture(fd,chunk);}catch{stop("restore_capture");}};
+                  child.stdout.on("data",onData(stdout));child.stderr.on("data",onData(stderr));
+                  child.stdout.on("error",()=>stop("restore_capture"));child.stderr.on("error",()=>stop("restore_capture"));
+                  child.once("error",()=>stop("restore_spawn"));
+                  child.once("exit",()=>{
+                    if(child.pid){
+                      try{process.kill(-child.pid,"SIGKILL");}catch(error){if(error.code!=="ESRCH")reason="restore_cleanup";}
+                    }
+                    armCleanup();
+                  });
+                  child.once("close",(code,signal)=>finish({code,signal}));
+                  poll=setInterval(()=>{try{drain();}catch{stop("restore_commands");}},10);
+                  deadline=setTimeout(()=>stop("restore_timeout"),timeoutMs);
+                });
+                drain();
+                if(reason)throw new Error(reason);
+                if(result.code!==0||result.signal!==null)throw new Error("restore_exit");
+                const raw=Buffer.concat(commands[0].chunks);
+                if(saveOnly){
+                  if(raw.length!==0)throw new Error("restore_outputs");
+                  return {};
+                }
+                if(!raw.length||raw.length>commandCap||raw.includes(0)||raw.includes(13))throw new Error("restore_outputs");
+                const lines=raw.toString("utf8").split("\n"),values=new Map();
+                if(lines.pop()!=="")throw new Error("restore_outputs");
+                for(let i=0;i<lines.length;i++){
+                  const line=lines[i];let name,value;
+                  const multiline=/^([a-z-]+)<<ghadelimiter_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/.exec(line);
+                  if(multiline){
+                    name=multiline[1];value=lines[++i];
+                    if(lines[++i]!=="ghadelimiter_"+multiline[2])throw new Error("restore_outputs");
+                  }else{
+                    const single=/^([a-z-]+)=(.*)$/.exec(line);
+                    if(!single)throw new Error("restore_outputs");
+                    [,name,value]=single;
+                  }
+                  if(!["cache-hit","cache-primary-key","cache-matched-key"].includes(name)||
+                      values.has(name)||value!==(name==="cache-hit"?"true":key))throw new Error("restore_outputs");
+                  values.set(name,value);
+                }
+                if(values.size!==3)throw new Error("restore_outputs");
+                return Object.fromEntries(values);
+              }finally{
+                clearInterval(poll);clearTimeout(deadline);clearTimeout(cleanup);
+                process.removeListener("SIGTERM",cancelled);process.removeListener("SIGINT",cancelled);
+                for(const fd of descriptors){try{fs.closeSync(fd);}catch{}}
+              }
+            }
+            try {
+              const mode=process.env.CACHE_MODE;
+              if(process.platform!=="linux"||process.versions.node.split(".")[0]!=="24"||
+                  process.execPath!==process.env.NODE_BINARY||!["lookup","restore","save"].includes(mode))throw new Error("restore_context");
+              if(mode==="save"){
+                const fs=require("node:fs"),path=require("node:path");
+                const root=path.join(process.env.GITHUB_WORKSPACE,".discrawl-ci"),info=fs.lstatSync(root);
+                if(!info.isDirectory()||info.isSymbolicLink()||
+                    process.env.EXPECTED_KEY!==`discrawl-discord-db-Linux-main-${process.env.GITHUB_RUN_ID}-1`)throw new Error("restore_context");
+                const directory=fs.opendirSync(root,{bufferSize:2});
+                try{
+                  if(directory.readSync()?.name!=="discrawl.db"||directory.readSync()!==null)throw new Error("restore_context");
+                }finally{directory.closeSync();}
+                const db=fs.lstatSync(path.join(root,"discrawl.db"));
+                if(!db.isFile()||db.isSymbolicLink()||db.nlink!==1||!Number.isSafeInteger(db.size)||
+                    db.size<=0||db.size>10*1024**3||(db.mode&0o777)!==0o600)throw new Error("restore_context");
+              }
+              const outputs=await containedCache({
+                node:process.execPath,entry:require("node:path").join(process.env.GITHUB_WORKSPACE,
+                  ".repair-cache-action/dist/"+(mode==="save"?"save-only":"restore-only")+"/index.js"),
+                workspace:process.env.GITHUB_WORKSPACE,privateRoot:process.env.PRIVATE_TEMP,key:process.env.EXPECTED_KEY,
+                lookupOnly:mode==="lookup"?"true":"false",saveOnly:mode==="save",timeoutMs:mode==="lookup"?110000:570000
+              });
+              for(const[name,value]of Object.entries(outputs))core.setOutput(name,value);
+            }catch(error){
+              const allowed=["restore_context","restore_cleanup","restore_cancelled","restore_capture_cap","restore_commands",
+                "restore_capture","restore_spawn","restore_timeout","restore_exit","restore_outputs"];
+              core.setFailed(allowed.includes(error?.message)?error.message:"restore_internal");
+            }
+
+      - name: Restore exact backed-up cache without fallback
+        id: restore
+        timeout-minutes: 10
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PRIVATE_TEMP: ${{ steps.build.outputs.private_temp }}
+          NODE_BINARY: ${{ steps.runtime.outputs.node_binary }}
+          EXPECTED_KEY: ${{ steps.before.outputs.key }}
+          CACHE_MODE: restore
+        with:
+          script: *contained_cache
+      - name: Revalidate main and winner before private copy
+        id: copy-gate
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PHASE: copy
+        with:
+          script: *metadata_guards
+      - name: Repair only the approved copied cells and strictly export
+        id: helper
+        timeout-minutes: 48
+        env:
+          PRIVATE_TEMP: ${{ steps.build.outputs.private_temp }}
+          NODE_BINARY: ${{ steps.runtime.outputs.node_binary }}
+        shell: bash
+        run: |
+          umask 077
+          mkdir -m 700 "$PRIVATE_TEMP/home"
+          if timeout --signal=TERM --kill-after=5s 47m env -i \
+            HOME="$PRIVATE_TEMP/home" TMPDIR="$PRIVATE_TEMP" PATH=/usr/bin:/bin \
+            XDG_CONFIG_HOME="$PRIVATE_TEMP/home" XDG_CACHE_HOME="$PRIVATE_TEMP/home" \
+            "$RUNNER_TEMP/repair-discord-cache" "$GITHUB_WORKSPACE/.discrawl-ci" "$PRIVATE_TEMP" \
+            > "$PRIVATE_TEMP/result.json" 2>/dev/null; then
+            helper_status=0
+          else
+            helper_status=$?
+          fi
+          env -i PATH=/usr/bin:/bin PRIVATE_TEMP="$PRIVATE_TEMP" HELPER_STATUS="$helper_status" "$NODE_BINARY" <<'JS'
+          const fs=require("node:fs");
+          try {
+            const file=process.env.PRIVATE_TEMP+"/result.json";
+            if(fs.statSync(file).size>4096)throw new Error();
+            const result=JSON.parse(fs.readFileSync(file,"utf8"));
+            const fields=["schema_version","scope","complete","stage","error","changed_cells","removed_bytes","tails","original_unchanged","export_rows"];
+            const tables=["guilds","channels","members","messages","message_events","message_attachments","mention_events","sync_state"];
+            const sameKeys=(value,names)=>value&&JSON.stringify(Object.keys(value).sort())===JSON.stringify([...names].sort());
+            const stages=["arguments","originals","copy","repair","reopen","standalone","export","stage","cache_ready"];
+            const errors=["arguments","input_files","capacity","copy","sqlite","schema","aggregate","cas","transaction",
+              "verification","time_limit","backup","strict_export","standalone_files","original_changed","staging","internal"];
+            if(sameKeys(result,fields)&&result.schema_version===1&&
+                result.scope==="restored_cache.message_attachments.text_content"&&result.complete===false&&
+                stages.includes(result.stage)&&errors.includes(result.error)&&typeof result.original_unchanged==="boolean"){
+              process.stdout.write(JSON.stringify({schema_version:1,complete:false,stage:result.stage,error:result.error,
+                original_unchanged:result.original_unchanged})+"\n");
+              process.exit(1);
+            }
+            if(!sameKeys(result,fields)||result.schema_version!==1||
+                result.scope!=="restored_cache.message_attachments.text_content"||result.complete!==true||
+                process.env.HELPER_STATUS!=="0"||
+                result.stage!=="cache_ready"||result.error!=="none"||result.changed_cells!==46||result.removed_bytes!==67||
+                JSON.stringify(result.tails)!=="[25,21,0]"||result.original_unchanged!==true||
+                !sameKeys(result.export_rows,tables)||Object.values(result.export_rows).some(n=>!Number.isSafeInteger(n)||n<0)||
+                result.export_rows.message_attachments!==15264)throw new Error();
+            process.stdout.write(JSON.stringify(result)+"\n");
+          }catch{process.stdout.write("::error::repair_output\n");process.exitCode=1;}
+          JS
+          printf 'cache_ready=true\n' >> "$GITHUB_OUTPUT"
+      - name: Revalidate main, backed-up winner and absent new key before save
+        id: save-gate
+        if: ${{ steps.helper.outputs.cache_ready == 'true' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PHASE: save
+        with:
+          script: *metadata_guards
+      - name: Save standalone repaired DB using contained stock save
+        id: save
+        if: ${{ steps.helper.outputs.cache_ready == 'true' && steps.save-gate.outcome == 'success' }}
+        timeout-minutes: 10
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PRIVATE_TEMP: ${{ steps.build.outputs.private_temp }}
+          NODE_BINARY: ${{ steps.runtime.outputs.node_binary }}
+          EXPECTED_KEY: ${{ steps.save-gate.outputs.new_key }}
+          CACHE_MODE: save
+        with:
+          script: *contained_cache
+      - name: Require immutable main-cache installation receipt
+        if: ${{ steps.save.outcome == 'success' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PHASE: after
+        with:
+          script: *metadata_guards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.14.1 - 2026-09-09
 
+- Add a manually gated, backup-first maintenance workflow for narrowly scoped attachment text repair, with strict snapshot validation before installing a new Actions database cache.
 - Keep extracted attachment text within its byte limit without splitting valid UTF-8 characters, and identify invalid admitted attachment columns in contents-free export errors without changing stored data or weakening snapshot validation.
 - Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.
 - Provide checked-out source and workflow run identity to Discord archive publications.

--- a/scripts/repair_discord_cache.go
+++ b/scripts/repair_discord_cache.go
@@ -1,0 +1,894 @@
+//go:build ignore
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"hash"
+	"io"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unicode/utf8"
+
+	"github.com/openclaw/crawlkit/snapshot"
+	"github.com/openclaw/discrawl/internal/share"
+	"modernc.org/sqlite"
+)
+
+const (
+	maxSourceBytes = int64(10 << 30)
+	reserveBytes   = int64(8 << 30)
+	maxTextBytes   = int64(256 << 20)
+	maxCellBytes   = int64(1 << 20)
+	expectedCells  = int64(15264)
+	expectedFixes  = int64(46)
+	expectedDrop   = int64(67)
+)
+
+var inputNames = []string{"discrawl.db", "discrawl.db-shm", "discrawl.db-wal"}
+
+const attachmentDDL = `CREATE TABLE message_attachments (
+	attachment_id text primary key, message_id text not null, guild_id text not null,
+	channel_id text not null, author_id text, filename text not null, content_type text,
+	size integer not null default 0, url text, proxy_url text, text_content text not null default '',
+	media_path text, content_sha256 text, content_size integer not null default 0,
+	fetched_at text, fetch_status text not null default '', fetch_error text not null default '',
+	updated_at text not null)`
+
+var attachmentColumns = []string{
+	"attachment_id", "message_id", "guild_id", "channel_id", "author_id", "filename",
+	"content_type", "size", "url", "proxy_url", "text_content", "media_path",
+	"content_sha256", "content_size", "fetched_at", "fetch_status", "fetch_error", "updated_at",
+}
+
+type repairResult struct {
+	SchemaVersion     int              `json:"schema_version"`
+	Scope             string           `json:"scope"`
+	Complete          bool             `json:"complete"`
+	Stage             string           `json:"stage"`
+	Error             string           `json:"error"`
+	ChangedCells      int64            `json:"changed_cells"`
+	RemovedBytes      int64            `json:"removed_bytes"`
+	Tails             [3]int64         `json:"tails"`
+	OriginalUnchanged bool             `json:"original_unchanged"`
+	ExportRows        map[string]int64 `json:"export_rows"`
+}
+
+func main() {
+	syscall.Umask(0077)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	ctx, deadline := context.WithTimeout(ctx, 45*time.Minute)
+	defer deadline()
+	result := runRepair(ctx, os.Args[1:])
+	if json.NewEncoder(os.Stdout).Encode(result) != nil || !result.Complete {
+		os.Exit(1)
+	}
+}
+
+type originalFile struct {
+	info os.FileInfo
+	hash [32]byte
+}
+
+func runRepair(ctx context.Context, args []string) (out repairResult) {
+	out = repairResult{SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
+		Stage: "arguments", Error: "arguments", ExportRows: map[string]int64{}}
+	defer func() {
+		if recover() != nil {
+			out.Complete, out.Error = false, "internal"
+		}
+	}()
+	if len(args) != 2 {
+		return out
+	}
+	source, scratch := args[0], args[1]
+	if !filepath.IsAbs(source) || !filepath.IsAbs(scratch) || filepath.Base(source) != ".discrawl-ci" {
+		return out
+	}
+	for _, directory := range []string{source, scratch} {
+		info, err := os.Lstat(directory)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return out
+		}
+	}
+	relative, err := filepath.Rel(source, scratch)
+	if err != nil || relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator))) {
+		return out
+	}
+	sourceInfo, _ := os.Stat(source)
+	scratchInfo, _ := os.Stat(scratch)
+	if sourceInfo.Sys().(*syscall.Stat_t).Dev != scratchInfo.Sys().(*syscall.Stat_t).Dev {
+		return out
+	}
+	out.Stage, out.Error = "originals", "input_files"
+	originals, total, err := inspectOriginals(source)
+	if err != nil {
+		return out
+	}
+	if err = capacity(scratch, total); err != nil {
+		out.Error = "capacity"
+		return out
+	}
+	for name, stamp := range originals {
+		stamp.hash, err = hashOriginal(ctx, source, name, stamp.info)
+		if err != nil {
+			return out
+		}
+		originals[name] = stamp
+	}
+	originalPath := source
+	defer func() {
+		checkCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		out.OriginalUnchanged = originalsMatch(checkCtx, originalPath, originals)
+		if !out.OriginalUnchanged {
+			out.Complete, out.Error = false, "original_changed"
+		}
+	}()
+	work, err := os.MkdirTemp(scratch, "repair-work-")
+	if err != nil {
+		out.Error = "copy"
+		return out
+	}
+	defer os.RemoveAll(work)
+	if err = os.Chmod(work, 0700); err != nil {
+		out.Error = "copy"
+		return out
+	}
+	out.Stage, out.Error = "copy", "copy"
+	for _, name := range inputNames {
+		stamp, exists := originals[name]
+		if !exists {
+			continue
+		}
+		if err = copyOriginal(ctx, source, work, name, stamp); err != nil {
+			return out
+		}
+	}
+	workDB := filepath.Join(work, inputNames[0])
+	out.Stage, out.Error = "repair", "sqlite"
+	db, logical, err := prepareWorkingDatabase(ctx, workDB, scratch, capacity)
+	if err != nil {
+		out.Error = fixedError(err)
+		return out
+	}
+	defer db.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return out
+	}
+	expectedHash, err := repairTransaction(ctx, conn, nil)
+	closeErr := conn.Close()
+	if err != nil || closeErr != nil {
+		out.Error = fixedError(err)
+		return out
+	}
+	if err = db.Close(); err != nil {
+		return out
+	}
+	out.ChangedCells, out.RemovedBytes, out.Tails = expectedFixes, expectedDrop, [3]int64{25, 21, 0}
+	out.Stage, out.Error = "reopen", "verification"
+	db, err = openDatabase(workDB, true)
+	if err != nil {
+		return out
+	}
+	defer db.Close()
+	if err = verifyRepaired(ctx, db, expectedHash); err != nil {
+		return out
+	}
+	sourceCounts, err := snapshotCounts(ctx, db)
+	if err != nil {
+		return out
+	}
+	stage, err := os.MkdirTemp(scratch, "repair-ready-")
+	if err != nil {
+		return out
+	}
+	defer os.RemoveAll(stage)
+	if err = os.Chmod(stage, 0700); err != nil {
+		return out
+	}
+	out.Stage, out.Error = "standalone", "backup"
+	standalone := filepath.Join(stage, inputNames[0])
+	if err = backupDatabase(ctx, db, standalone, scratch); err != nil {
+		return out
+	}
+	if err = db.Close(); err != nil {
+		return out
+	}
+	ready, err := openDatabase(standalone, true)
+	if err != nil {
+		return out
+	}
+	defer ready.Close()
+	if err = verifyRepaired(ctx, ready, expectedHash); err != nil {
+		out.Error = "verification"
+		return out
+	}
+	out.Stage, out.Error = "export", "strict_export"
+	exportDir, err := os.MkdirTemp(scratch, "repair-export-")
+	if err != nil {
+		return out
+	}
+	defer os.RemoveAll(exportDir)
+	if err = os.Chmod(exportDir, 0700); err != nil {
+		return out
+	}
+	out.ExportRows, err = strictExport(ctx, ready, exportDir, scratch, logical, sourceCounts)
+	if err != nil {
+		return out
+	}
+	if err = ready.Close(); err != nil {
+		return out
+	}
+	entries, err := os.ReadDir(stage)
+	if err != nil || len(entries) != 1 || entries[0].Name() != inputNames[0] {
+		out.Error = "standalone_files"
+		return out
+	}
+	if info, err := os.Lstat(standalone); err != nil || !info.Mode().IsRegular() ||
+		info.Size() <= 0 || info.Size() > maxSourceBytes || info.Sys().(*syscall.Stat_t).Nlink != 1 {
+		out.Error = "standalone_files"
+		return out
+	}
+	if err = os.Chmod(standalone, 0600); err != nil || !originalsMatch(ctx, source, originals) {
+		out.Error = "original_changed"
+		return out
+	}
+	out.Stage, out.Error = "stage", "staging"
+	kept := filepath.Join(scratch, "originals")
+	if _, err = os.Lstat(kept); !errors.Is(err, os.ErrNotExist) {
+		return out
+	}
+	if err = os.Rename(source, kept); err != nil {
+		return out
+	}
+	originalPath = kept
+	if err = os.Rename(stage, source); err != nil {
+		if os.Rename(kept, source) == nil {
+			originalPath = source
+		}
+		return out
+	}
+	out.Stage, out.Error, out.Complete = "cache_ready", "none", true
+	return out
+}
+
+func fixedError(err error) string {
+	for _, value := range []string{"schema", "aggregate", "cas", "transaction", "verification", "capacity", "time_limit"} {
+		if err != nil && err.Error() == value {
+			return value
+		}
+	}
+	return "sqlite"
+}
+
+func inspectOriginals(directory string) (map[string]originalFile, int64, error) {
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, 0, errors.New("input_files")
+	}
+	defer root.Close()
+	dir, err := root.Open(".")
+	if err != nil {
+		return nil, 0, errors.New("input_files")
+	}
+	entries, readErr := dir.ReadDir(4)
+	closeErr := dir.Close()
+	if (readErr != nil && !errors.Is(readErr, io.EOF)) || closeErr != nil || len(entries) > 3 {
+		return nil, 0, errors.New("input_files")
+	}
+	files, total := map[string]originalFile{}, int64(0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if name != inputNames[0] && name != inputNames[1] && name != inputNames[2] {
+			return nil, 0, errors.New("input_files")
+		}
+		info, err := root.Lstat(name)
+		if err != nil || !info.Mode().IsRegular() || info.Sys().(*syscall.Stat_t).Nlink != 1 ||
+			info.Size() < 0 || info.Size() > maxSourceBytes-total {
+			return nil, 0, errors.New("input_files")
+		}
+		total += info.Size()
+		files[name] = originalFile{info: info}
+	}
+	if file, ok := files[inputNames[0]]; !ok || file.info.Size() == 0 {
+		return nil, 0, errors.New("input_files")
+	}
+	return files, total, nil
+}
+
+func openOriginal(directory, name string, expected os.FileInfo) (*os.File, error) {
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	file, err := root.OpenFile(name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil || !os.SameFile(info, expected) || !info.Mode().IsRegular() ||
+		info.Size() != expected.Size() || info.Sys().(*syscall.Stat_t).Nlink != 1 {
+		file.Close()
+		return nil, errors.New("input_files")
+	}
+	return file, nil
+}
+
+type boundedReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r boundedReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+func hashOriginal(ctx context.Context, directory, name string, info os.FileInfo) ([32]byte, error) {
+	file, err := openOriginal(directory, name, info)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer file.Close()
+	digest := sha256.New()
+	n, err := io.Copy(digest, boundedReader{ctx, io.LimitReader(file, info.Size()+1)})
+	if err != nil || n != info.Size() {
+		return [32]byte{}, errors.New("input_files")
+	}
+	var result [32]byte
+	copy(result[:], digest.Sum(nil))
+	return result, nil
+}
+
+func originalsMatch(ctx context.Context, directory string, before map[string]originalFile) bool {
+	after, _, err := inspectOriginals(directory)
+	if err != nil || len(after) != len(before) {
+		return false
+	}
+	for name, stamp := range before {
+		current, exists := after[name]
+		if !exists || !os.SameFile(stamp.info, current.info) || stamp.info.Mode() != current.info.Mode() {
+			return false
+		}
+		digest, err := hashOriginal(ctx, directory, name, stamp.info)
+		if err != nil || digest != stamp.hash {
+			return false
+		}
+	}
+	return true
+}
+
+func capacity(directory string, additional int64) error {
+	var space syscall.Statfs_t
+	if additional < 0 || syscall.Statfs(directory, &space) != nil || space.Bsize <= 0 {
+		return errors.New("capacity")
+	}
+	free := uint64(space.Bsize) * space.Bavail
+	if free < uint64(additional+reserveBytes) {
+		return errors.New("capacity")
+	}
+	return nil
+}
+
+func copyOriginal(ctx context.Context, source, destination, name string, stamp originalFile) error {
+	input, err := openOriginal(source, name, stamp.info)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.OpenFile(filepath.Join(destination, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+	digest := sha256.New()
+	buffer := make([]byte, 1<<20)
+	left := stamp.info.Size()
+	for left > 0 {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+		if err = capacity(destination, int64(len(buffer))); err != nil {
+			return err
+		}
+		n, readErr := input.Read(buffer[:min(int64(len(buffer)), left)])
+		if n > 0 {
+			if _, err = output.Write(buffer[:n]); err != nil {
+				return err
+			}
+			digest.Write(buffer[:n])
+			left -= int64(n)
+		}
+		if readErr != nil && !(errors.Is(readErr, io.EOF) && left == 0) {
+			return readErr
+		}
+		if n == 0 && left > 0 {
+			return io.ErrUnexpectedEOF
+		}
+	}
+	if !bytes.Equal(digest.Sum(nil), stamp.hash[:]) {
+		return errors.New("input_files")
+	}
+	if err = output.Sync(); err != nil {
+		return err
+	}
+	return output.Close()
+}
+
+func openDatabase(file string, readOnly bool) (*sql.DB, error) {
+	u := &url.URL{Scheme: "file", Path: file}
+	query := url.Values{"mode": {"rw"}, "_pragma": {"busy_timeout(0)", "trusted_schema(OFF)"}}
+	if readOnly {
+		query.Set("mode", "ro")
+		query.Add("_pragma", "query_only(ON)")
+	}
+	u.RawQuery = query.Encode()
+	db, err := sql.Open("sqlite", u.String())
+	if err == nil {
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+	}
+	return db, err
+}
+
+func logicalBytes(ctx context.Context, db *sql.DB) (int64, error) {
+	var pages, size int64
+	if db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pages) != nil ||
+		db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&size) != nil ||
+		pages <= 0 || size <= 0 || pages > maxSourceBytes/size {
+		return 0, errors.New("capacity")
+	}
+	return pages * size, nil
+}
+
+func prepareWorkingDatabase(ctx context.Context, file, scratch string, admit func(string, int64) error) (*sql.DB, int64, error) {
+	// Admit a full measured checkpoint before opening a writer: its close can
+	// also checkpoint a WAL, including on an early error path.
+	inspection, err := openDatabase(file, true)
+	if err != nil {
+		return nil, 0, errors.New("sqlite")
+	}
+	logical, err := logicalBytes(ctx, inspection)
+	closeErr := inspection.Close()
+	if err != nil {
+		return nil, 0, err
+	}
+	if closeErr != nil {
+		return nil, 0, errors.New("sqlite")
+	}
+	if err = admit(scratch, logical); err != nil {
+		return nil, 0, errors.New("capacity")
+	}
+	db, err := openDatabase(file, false)
+	if err != nil {
+		return nil, 0, errors.New("sqlite")
+	}
+	var journal string
+	if err = db.QueryRowContext(ctx, "PRAGMA journal_mode=DELETE").Scan(&journal); err != nil || journal != "delete" {
+		db.Close()
+		return nil, 0, errors.New("sqlite")
+	}
+	// Recheck resident space after consolidation for rollback and backup.
+	if err = admit(scratch, 2*logical); err != nil {
+		db.Close()
+		return nil, 0, errors.New("capacity")
+	}
+	return db, logical, nil
+}
+
+type candidate struct {
+	rowid int64
+	old   []byte
+	tail  int
+}
+
+func incompleteTail(value []byte) int {
+	if len(value) != 8192 || utf8.Valid(value) {
+		return 0
+	}
+	for count := 1; count <= 3; count++ {
+		prefix, tail := value[:len(value)-count], value[len(value)-count:]
+		if utf8.Valid(prefix) && !utf8.FullRune(tail) {
+			return count
+		}
+	}
+	return 0
+}
+
+func validateSchema(ctx context.Context, conn *sql.Conn) error {
+	var encoding, ddl, kind string
+	var triggers int
+	if conn.QueryRowContext(ctx, "PRAGMA encoding").Scan(&encoding) != nil || encoding != "UTF-8" ||
+		conn.QueryRowContext(ctx, "SELECT type, sql FROM main.sqlite_schema WHERE name='message_attachments'").Scan(&kind, &ddl) != nil ||
+		kind != "table" || conn.QueryRowContext(ctx, "SELECT count(*) FROM main.sqlite_schema WHERE type='trigger' AND tbl_name='message_attachments'").Scan(&triggers) != nil || triggers != 0 {
+		return errors.New("schema")
+	}
+	if normalizedDDL(ddl) != normalizedDDL(attachmentDDL) {
+		return errors.New("schema")
+	}
+	rows, err := conn.QueryContext(ctx, "PRAGMA main.index_list(message_attachments)")
+	if err != nil {
+		return errors.New("schema")
+	}
+	var names []string
+	for rows.Next() {
+		var seq, unique, partial int
+		var name, origin string
+		if rows.Scan(&seq, &name, &unique, &origin, &partial) != nil || partial != 0 {
+			rows.Close()
+			return errors.New("schema")
+		}
+		names = append(names, name)
+	}
+	err = rows.Err()
+	closeErr := rows.Close()
+	if err != nil || closeErr != nil {
+		return errors.New("schema")
+	}
+	for _, name := range names {
+		index, err := conn.QueryContext(ctx, "SELECT cid, name, key FROM pragma_index_xinfo(?)", name)
+		if err != nil {
+			return errors.New("schema")
+		}
+		for index.Next() {
+			var cid, key int
+			var column sql.NullString
+			if index.Scan(&cid, &column, &key) != nil || cid < -1 || column.String == "text_content" {
+				index.Close()
+				return errors.New("schema")
+			}
+		}
+		err = index.Err()
+		closeErr = index.Close()
+		if err != nil || closeErr != nil {
+			return errors.New("schema")
+		}
+	}
+	return nil
+}
+
+func normalizedDDL(value string) string {
+	value = strings.TrimSuffix(strings.TrimSpace(value), ";")
+	var normalized strings.Builder
+	quoted := false
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if char == '\'' {
+			normalized.WriteByte(char)
+			if quoted && index+1 < len(value) && value[index+1] == '\'' {
+				index++
+				normalized.WriteByte('\'')
+			} else {
+				quoted = !quoted
+			}
+		} else if quoted {
+			normalized.WriteByte(char)
+		} else if !strings.ContainsRune(" \t\r\n", rune(char)) {
+			if char >= 'A' && char <= 'Z' {
+				char += 'a' - 'A'
+			}
+			normalized.WriteByte(char)
+		}
+	}
+	return normalized.String()
+}
+
+func frame(digest hash.Hash, value []byte) {
+	var length [8]byte
+	binary.LittleEndian.PutUint64(length[:], uint64(len(value)))
+	digest.Write(length[:])
+	digest.Write(value)
+}
+
+func attachmentSnapshot(ctx context.Context, conn *sql.Conn, before bool) ([32]byte, []candidate, error) {
+	var count, byteCount, largest int64
+	if conn.QueryRowContext(ctx, `SELECT count(*), coalesce(sum(length(CAST(text_content AS BLOB))),0),
+		coalesce(max(length(CAST(text_content AS BLOB))),0) FROM main.message_attachments`).Scan(&count, &byteCount, &largest) != nil ||
+		count != expectedCells || byteCount > maxTextBytes || largest > maxCellBytes {
+		return [32]byte{}, nil, errors.New("aggregate")
+	}
+	parts := []string{"rowid"}
+	for _, column := range attachmentColumns {
+		parts = append(parts, `typeof("`+column+`")`, `CAST("`+column+`" AS BLOB)`)
+	}
+	rows, err := conn.QueryContext(ctx, "SELECT "+strings.Join(parts, ",")+" FROM main.message_attachments ORDER BY rowid")
+	if err != nil {
+		return [32]byte{}, nil, err
+	}
+	defer rows.Close()
+	digest := sha256.New()
+	var candidates []candidate
+	var valid, seen int64
+	var tails [3]int64
+	for rows.Next() {
+		var rowid int64
+		types := make([]string, len(attachmentColumns))
+		values := make([][]byte, len(attachmentColumns))
+		dest := []any{&rowid}
+		for i := range types {
+			dest = append(dest, &types[i], &values[i])
+		}
+		if rows.Scan(dest...) != nil || types[10] != "text" || int64(len(values[10])) > maxCellBytes {
+			return [32]byte{}, nil, errors.New("aggregate")
+		}
+		value := values[10]
+		if utf8.Valid(value) {
+			valid++
+		} else {
+			tail := incompleteTail(value)
+			if !before || tail == 0 || len(candidates) >= int(expectedFixes) {
+				return [32]byte{}, nil, errors.New("aggregate")
+			}
+			candidates = append(candidates, candidate{rowid, bytes.Clone(value), tail})
+			tails[tail-1]++
+			values[10] = value[:len(value)-tail]
+		}
+		var id [8]byte
+		binary.LittleEndian.PutUint64(id[:], uint64(rowid))
+		frame(digest, id[:])
+		for i := range types {
+			frame(digest, []byte(types[i]))
+			frame(digest, values[i])
+		}
+		seen++
+	}
+	if rows.Err() != nil || seen != expectedCells ||
+		(before && (valid != 15218 || tails != [3]int64{25, 21, 0})) || (!before && valid != expectedCells) {
+		return [32]byte{}, nil, errors.New("aggregate")
+	}
+	var result [32]byte
+	copy(result[:], digest.Sum(nil))
+	return result, candidates, nil
+}
+
+func repairTransaction(ctx context.Context, conn *sql.Conn, hook func(*sql.Conn, int) error) ([32]byte, error) {
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return [32]byte{}, errors.New("transaction")
+	}
+	defer conn.ExecContext(context.Background(), "ROLLBACK")
+	if err := validateSchema(ctx, conn); err != nil {
+		return [32]byte{}, err
+	}
+	expected, candidates, err := attachmentSnapshot(ctx, conn, true)
+	if err != nil || len(candidates) != int(expectedFixes) {
+		return [32]byte{}, errors.New("aggregate")
+	}
+	var start int64
+	if conn.QueryRowContext(ctx, "SELECT total_changes()").Scan(&start) != nil {
+		return [32]byte{}, errors.New("transaction")
+	}
+	var removed int64
+	for index, cell := range candidates {
+		if hook != nil {
+			if err = hook(conn, index); err != nil {
+				return [32]byte{}, errors.New("transaction")
+			}
+		}
+		prefix := cell.old[:len(cell.old)-cell.tail]
+		if !utf8.Valid(prefix) {
+			return [32]byte{}, errors.New("aggregate")
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE main.message_attachments
+			SET text_content = CAST(?1 AS TEXT)
+			WHERE rowid = ?2 AND typeof(text_content) = 'text' AND CAST(text_content AS BLOB) = ?3`,
+			prefix, cell.rowid, cell.old)
+		if err != nil {
+			return [32]byte{}, errors.New("cas")
+		}
+		n, err := result.RowsAffected()
+		if err != nil || n != 1 {
+			return [32]byte{}, errors.New("cas")
+		}
+		removed += int64(cell.tail)
+	}
+	var end int64
+	actual, _, err := attachmentSnapshot(ctx, conn, false)
+	if err != nil || actual != expected || removed != expectedDrop ||
+		conn.QueryRowContext(ctx, "SELECT total_changes()").Scan(&end) != nil || end-start != expectedFixes {
+		return [32]byte{}, errors.New("verification")
+	}
+	if _, err = conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return [32]byte{}, errors.New("transaction")
+	}
+	return expected, nil
+}
+
+func verifyRepaired(ctx context.Context, db *sql.DB, expected [32]byte) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	rows, err := conn.QueryContext(ctx, "PRAGMA integrity_check")
+	if err != nil {
+		return err
+	}
+	count := 0
+	for rows.Next() {
+		var value string
+		if rows.Scan(&value) != nil || value != "ok" {
+			rows.Close()
+			return errors.New("verification")
+		}
+		count++
+	}
+	err = rows.Err()
+	closeErr := rows.Close()
+	if err != nil || closeErr != nil || count != 1 || validateSchema(ctx, conn) != nil {
+		return errors.New("verification")
+	}
+	actual, _, err := attachmentSnapshot(ctx, conn, false)
+	if err != nil || actual != expected {
+		return errors.New("verification")
+	}
+	return nil
+}
+
+func backupDatabase(ctx context.Context, db *sql.DB, destination, scratch string) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if _, err = os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("backup")
+	}
+	return conn.Raw(func(driver any) (resultErr error) {
+		backup, err := driver.(interface {
+			NewBackup(string) (*sqlite.Backup, error)
+		}).NewBackup(destination)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := backup.Finish(); resultErr == nil {
+				resultErr = err
+			}
+		}()
+		for {
+			if err = ctx.Err(); err != nil {
+				return err
+			}
+			if err = capacity(scratch, 8<<20); err != nil {
+				return err
+			}
+			more, err := backup.Step(256)
+			if err != nil {
+				return err
+			}
+			if info, err := os.Stat(destination); err != nil || info.Size() > maxSourceBytes {
+				return errors.New("capacity")
+			}
+			if !more {
+				return nil
+			}
+		}
+	})
+}
+
+type rowCounter interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func snapshotCounts(ctx context.Context, reader rowCounter) (map[string]int64, error) {
+	counts := make(map[string]int64, len(share.SnapshotTables))
+	for _, table := range share.SnapshotTables {
+		var count int64
+		if reader.QueryRowContext(ctx, `SELECT count(*) FROM "`+table+`"`).Scan(&count) != nil || count < 0 {
+			return nil, errors.New("strict_export")
+		}
+		counts[table] = count
+	}
+	return counts, nil
+}
+
+func strictExport(ctx context.Context, db *sql.DB, directory, scratch string, logical int64, sourceCounts map[string]int64) (map[string]int64, error) {
+	if capacity(scratch, 40<<20) != nil {
+		return nil, errors.New("capacity")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var exceeded atomic.Bool
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	defer func() {
+		close(done)
+		<-stopped
+	}()
+	// Only metadata is monitored; the existing exporter owns all row encoding.
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if capacity(scratch, 40<<20) != nil || exportBytes(directory) > 2*logical+(40<<20) {
+					exceeded.Store(true)
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	counts, err := snapshotCounts(ctx, tx)
+	if err != nil || !reflect.DeepEqual(counts, sourceCounts) {
+		return nil, errors.New("strict_export")
+	}
+	manifest, err := snapshot.Export(ctx, snapshot.ExportOptions{ReadTx: tx, RootDir: directory,
+		Tables: share.SnapshotTables, MaxShardBytes: 40 << 20})
+	if err != nil || exceeded.Load() || capacity(scratch, 0) != nil ||
+		exportBytes(directory) > 2*logical+(40<<20) || len(manifest.Tables) != 8 {
+		return nil, errors.New("strict_export")
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, errors.New("strict_export")
+	}
+	disk, err := snapshot.ReadManifest(directory)
+	if err != nil || !reflect.DeepEqual(disk, manifest) {
+		return nil, errors.New("strict_export")
+	}
+	seen := map[string]bool{}
+	for _, table := range manifest.Tables {
+		expected, exists := counts[table.Name]
+		if !exists || seen[table.Name] || int64(table.Rows) != expected {
+			return nil, errors.New("strict_export")
+		}
+		seen[table.Name] = true
+	}
+	return counts, nil
+}
+
+func exportBytes(directory string) int64 {
+	var size int64
+	entries := 0
+	err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, err error) error {
+		entries++
+		if err != nil || entries > 100000 || entry.Type()&os.ModeSymlink != 0 {
+			return errors.New("capacity")
+		}
+		if !entry.IsDir() {
+			info, err := entry.Info()
+			if err != nil || !info.Mode().IsRegular() || info.Size() < 0 {
+				return errors.New("capacity")
+			}
+			size += info.Size()
+			if size > 2*maxSourceBytes+(40<<20) {
+				return errors.New("capacity")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 2*maxSourceBytes + (40 << 20) + 1
+	}
+	return size
+}

--- a/scripts/repair_discord_cache.go
+++ b/scripts/repair_discord_cache.go
@@ -68,7 +68,7 @@ type repairResult struct {
 }
 
 func main() {
-	syscall.Umask(0077)
+	syscall.Umask(0o077)
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	ctx, deadline := context.WithTimeout(ctx, 45*time.Minute)
@@ -85,8 +85,10 @@ type originalFile struct {
 }
 
 func runRepair(ctx context.Context, args []string) (out repairResult) {
-	out = repairResult{SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
-		Stage: "arguments", Error: "arguments", ExportRows: map[string]int64{}}
+	out = repairResult{
+		SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
+		Stage: "arguments", Error: "arguments", ExportRows: map[string]int64{},
+	}
 	defer func() {
 		if recover() != nil {
 			out.Complete, out.Error = false, "internal"
@@ -145,7 +147,7 @@ func runRepair(ctx context.Context, args []string) (out repairResult) {
 		return out
 	}
 	defer os.RemoveAll(work)
-	if err = os.Chmod(work, 0700); err != nil {
+	if err = os.Chmod(work, 0o700); err != nil {
 		out.Error = "copy"
 		return out
 	}
@@ -199,7 +201,7 @@ func runRepair(ctx context.Context, args []string) (out repairResult) {
 		return out
 	}
 	defer os.RemoveAll(stage)
-	if err = os.Chmod(stage, 0700); err != nil {
+	if err = os.Chmod(stage, 0o700); err != nil {
 		return out
 	}
 	out.Stage, out.Error = "standalone", "backup"
@@ -225,7 +227,7 @@ func runRepair(ctx context.Context, args []string) (out repairResult) {
 		return out
 	}
 	defer os.RemoveAll(exportDir)
-	if err = os.Chmod(exportDir, 0700); err != nil {
+	if err = os.Chmod(exportDir, 0o700); err != nil {
 		return out
 	}
 	out.ExportRows, err = strictExport(ctx, ready, exportDir, scratch, logical, sourceCounts)
@@ -245,7 +247,7 @@ func runRepair(ctx context.Context, args []string) (out repairResult) {
 		out.Error = "standalone_files"
 		return out
 	}
-	if err = os.Chmod(standalone, 0600); err != nil || !originalsMatch(ctx, source, originals) {
+	if err = os.Chmod(standalone, 0o600); err != nil || !originalsMatch(ctx, source, originals) {
 		out.Error = "original_changed"
 		return out
 	}
@@ -395,7 +397,7 @@ func copyOriginal(ctx context.Context, source, destination, name string, stamp o
 		return err
 	}
 	defer input.Close()
-	output, err := os.OpenFile(filepath.Join(destination, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	output, err := os.OpenFile(filepath.Join(destination, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
 	}
@@ -843,8 +845,10 @@ func strictExport(ctx context.Context, db *sql.DB, directory, scratch string, lo
 	if err != nil || !reflect.DeepEqual(counts, sourceCounts) {
 		return nil, errors.New("strict_export")
 	}
-	manifest, err := snapshot.Export(ctx, snapshot.ExportOptions{ReadTx: tx, RootDir: directory,
-		Tables: share.SnapshotTables, MaxShardBytes: 40 << 20})
+	manifest, err := snapshot.Export(ctx, snapshot.ExportOptions{
+		ReadTx: tx, RootDir: directory,
+		Tables: share.SnapshotTables, MaxShardBytes: 40 << 20,
+	})
 	if err != nil || exceeded.Load() || capacity(scratch, 0) != nil ||
 		exportBytes(directory) > 2*logical+(40<<20) || len(manifest.Tables) != 8 {
 		return nil, errors.New("strict_export")

--- a/scripts/repair_discord_cache_test.go
+++ b/scripts/repair_discord_cache_test.go
@@ -1,0 +1,983 @@
+//go:build ignore
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/openclaw/discrawl/internal/share"
+	"github.com/openclaw/discrawl/internal/store"
+	"go.yaml.in/yaml/v3"
+)
+
+func repairFixture(t *testing.T, wal bool) (string, *sql.DB) {
+	t.Helper()
+	source := filepath.Join(t.TempDir(), ".discrawl-ci")
+	if err := os.Mkdir(source, 0700); err != nil {
+		t.Fatal(err)
+	}
+	s, err := store.Open(context.Background(), filepath.Join(source, inputNames[0]))
+	if err != nil {
+		t.Fatal("synthetic store creation failed")
+	}
+	db := s.DB()
+	t.Cleanup(func() { s.Close() })
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO message_attachments
+		(attachment_id,message_id,guild_id,channel_id,filename,text_content,updated_at)
+		VALUES(?,?,?,?,?,CAST(? AS TEXT),?)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < int(expectedCells); index++ {
+		value := []byte("valid \ufffd")
+		if index < 25 {
+			value = append(bytes.Repeat([]byte("a"), 8191), 0xc2)
+		} else if index < 46 {
+			value = append(bytes.Repeat([]byte("b"), 8190), 0xe2, 0x82)
+		} else if index < 378 {
+			value = bytes.Repeat([]byte("v"), 8192)
+		}
+		if _, err = stmt.Exec(strconv.Itoa(index), "message", "guild", "channel", "fixture", value, "unchanged"); err != nil {
+			t.Fatal("synthetic attachment insertion failed")
+		}
+	}
+	if err = stmt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range share.SnapshotTables {
+		if table == "message_attachments" {
+			continue
+		}
+		columns, err := db.Query(`SELECT name,type FROM pragma_table_info(?)`, table)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var names, placeholders []string
+		var values []any
+		for columns.Next() {
+			var name, kind string
+			if columns.Scan(&name, &kind) != nil {
+				t.Fatal("synthetic schema read failed")
+			}
+			names = append(names, `"`+name+`"`)
+			placeholders = append(placeholders, "?")
+			if strings.Contains(strings.ToLower(kind), "int") {
+				values = append(values, 1)
+			} else {
+				values = append(values, "{}")
+			}
+		}
+		if err = columns.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = db.Exec(`INSERT INTO "`+table+`" (`+strings.Join(names, ",")+`) VALUES (`+strings.Join(placeholders, ",")+")", values...); err != nil {
+			t.Fatal("synthetic snapshot table insertion failed")
+		}
+	}
+	if !wal {
+		if _, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = db.Exec("PRAGMA journal_mode=DELETE"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return source, db
+}
+
+func logicalTable(t *testing.T, db *sql.DB, table string) []byte {
+	t.Helper()
+	rows, err := db.Query(`SELECT * FROM "` + table + `" ORDER BY rowid`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result [][]any
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(values))
+		for index := range pointers {
+			pointers[index] = &values[index]
+		}
+		if rows.Scan(pointers...) != nil {
+			t.Fatal("synthetic comparison read failed")
+		}
+		for index, value := range values {
+			if text, ok := value.(string); ok {
+				values[index] = []byte(text)
+			}
+		}
+		result = append(result, values)
+	}
+	if rows.Err() != nil {
+		t.Fatal("synthetic comparison incomplete")
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestExactRepairStandaloneExport(t *testing.T) {
+	source, db := repairFixture(t, false)
+	before := map[string][]byte{}
+	for _, table := range share.SnapshotTables {
+		if table != "message_attachments" {
+			before[table] = logicalTable(t, db, table)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	scratch := t.TempDir()
+	result := runRepair(context.Background(), []string{source, scratch})
+	if !result.Complete || result.Error != "none" || !result.OriginalUnchanged ||
+		result.ChangedCells != 46 || result.RemovedBytes != 67 || result.Tails != [3]int64{25, 21, 0} ||
+		len(result.ExportRows) != 8 || result.ExportRows["message_attachments"] != expectedCells {
+		t.Fatalf("repair proof failed: stage=%s error=%s", result.Stage, result.Error)
+	}
+	assertResultPrivacy(t, result)
+	files, err := os.ReadDir(source)
+	if err != nil || len(files) != 1 || files[0].Name() != inputNames[0] {
+		t.Fatal("standalone output retained sidecars")
+	}
+	ready, err := openDatabase(filepath.Join(source, inputNames[0]), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ready.Close()
+	var count, removed int64
+	if err = ready.QueryRow(`SELECT count(*),sum(8192-length(CAST(text_content AS BLOB)))
+		FROM message_attachments WHERE CAST(attachment_id AS INTEGER)<46`).Scan(&count, &removed); err != nil ||
+		count != 46 || removed != 67 {
+		t.Fatal("exact suffix totals changed")
+	}
+	var replaced, updated int
+	if ready.QueryRow(`SELECT count(*) FROM message_attachments WHERE text_content='valid `+"\ufffd"+`'`).Scan(&replaced) != nil ||
+		replaced != int(expectedCells)-378 ||
+		ready.QueryRow(`SELECT count(*) FROM message_attachments WHERE updated_at!='unchanged'`).Scan(&updated) != nil || updated != 0 {
+		t.Fatal("valid replacement character or unrelated field changed")
+	}
+	for table, expected := range before {
+		if !bytes.Equal(expected, logicalTable(t, ready, table)) {
+			t.Fatal("unrelated table changed")
+		}
+	}
+	if _, err = os.Stat(filepath.Join(scratch, "originals", inputNames[0])); err != nil {
+		t.Fatal("original file set was not retained")
+	}
+}
+
+func TestRepairRollbackAndAdmission(t *testing.T) {
+	for _, scenario := range []string{"interior", "overlong", "surrogate", "continuation", "wrong-length",
+		"missing-candidate", "blob", "schema", "trigger", "text-index", "cas", "mid-transaction"} {
+		t.Run(scenario, func(t *testing.T) {
+			source, db := repairFixture(t, false)
+			switch scenario {
+			case "interior", "overlong", "surrogate", "continuation", "wrong-length", "missing-candidate":
+				body := append(bytes.Repeat([]byte("a"), 8191), 0xff)
+				switch scenario {
+				case "overlong":
+					body = append(bytes.Repeat([]byte("a"), 8190), 0xc0, 0xaf)
+				case "surrogate":
+					body = append(bytes.Repeat([]byte("a"), 8189), 0xed, 0xa0, 0x80)
+				case "continuation":
+					body = append(bytes.Repeat([]byte("a"), 8191), 0x80)
+				case "wrong-length":
+					body = append(bytes.Repeat([]byte("a"), 8190), 0xc2)
+				case "missing-candidate":
+					body = bytes.Repeat([]byte("a"), 8192)
+				}
+				if _, err := db.Exec("UPDATE message_attachments SET text_content=CAST(? AS TEXT) WHERE rowid=1", body); err != nil {
+					t.Fatal(err)
+				}
+			case "blob":
+				if _, err := db.Exec("UPDATE message_attachments SET text_content=CAST(text_content AS BLOB) WHERE rowid=1"); err != nil {
+					t.Fatal(err)
+				}
+			case "schema":
+				if _, err := db.Exec("ALTER TABLE message_attachments ADD COLUMN unexpected TEXT"); err != nil {
+					t.Fatal(err)
+				}
+			case "trigger":
+				if _, err := db.Exec("CREATE TRIGGER unexpected AFTER UPDATE ON message_attachments BEGIN UPDATE sync_state SET cursor='changed'; END"); err != nil {
+					t.Fatal(err)
+				}
+			case "text-index":
+				if _, err := db.Exec("CREATE INDEX unexpected ON message_attachments(text_content)"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before := logicalTable(t, db, "message_attachments")
+			conn, err := db.Conn(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var hook func(*sql.Conn, int) error
+			if scenario == "cas" {
+				hook = func(c *sql.Conn, index int) error {
+					if index == 0 {
+						_, err := c.ExecContext(context.Background(), "UPDATE message_attachments SET text_content='changed' WHERE rowid=1")
+						return err
+					}
+					return nil
+				}
+			} else if scenario == "mid-transaction" {
+				hook = func(_ *sql.Conn, index int) error {
+					if index == 23 {
+						return errors.New("PRIVATE_PAYLOAD_MARKER")
+					}
+					return nil
+				}
+			}
+			_, repairErr := repairTransaction(context.Background(), conn, hook)
+			conn.Close()
+			if repairErr == nil || !bytes.Equal(before, logicalTable(t, db, "message_attachments")) {
+				t.Fatal("rejected repair did not roll back atomically")
+			}
+			if strings.Contains(repairErr.Error(), "PRIVATE_PAYLOAD_MARKER") {
+				t.Fatal("injected private error escaped")
+			}
+			_ = source
+		})
+	}
+}
+
+func TestStrictExportRejectsOtherInvalidColumn(t *testing.T) {
+	source, db := repairFixture(t, false)
+	if _, err := db.Exec("UPDATE messages SET content=CAST(x'ff' AS TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	result := runRepair(context.Background(), []string{source, t.TempDir()})
+	if result.Complete || result.Stage != "export" || result.Error != "strict_export" || !result.OriginalUnchanged {
+		t.Fatalf("invalid unrelated text admitted: stage=%s error=%s", result.Stage, result.Error)
+	}
+	assertResultPrivacy(t, result)
+}
+
+func TestWALOriginalFilesPreserved(t *testing.T) {
+	source, db := repairFixture(t, true)
+	before, _, err := inspectOriginals(source)
+	if err != nil || before[inputNames[2]].info == nil || before[inputNames[2]].info.Size() == 0 {
+		t.Fatal("synthetic WAL commits missing")
+	}
+	for name, stamp := range before {
+		stamp.hash, err = hashOriginal(context.Background(), source, name, stamp.info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[name] = stamp
+	}
+	result := runRepair(context.Background(), []string{source, t.TempDir()})
+	if !result.Complete || !result.OriginalUnchanged {
+		t.Fatalf("WAL-inclusive repair failed: stage=%s error=%s", result.Stage, result.Error)
+	}
+	db.Close()
+}
+
+func TestStrictCandidateClassifier(t *testing.T) {
+	for _, test := range []struct {
+		tail []byte
+		want int
+	}{
+		{[]byte{0xc2}, 1}, {[]byte{0xe2, 0x82}, 2}, {[]byte{0xf0, 0x9f, 0x92}, 3},
+		{[]byte{0xff}, 0}, {[]byte{0xc0, 0xaf}, 0}, {[]byte{0xed, 0xa0, 0x80}, 0},
+		{[]byte("\ufffd"), 0},
+	} {
+		value := append(bytes.Repeat([]byte("a"), 8192-len(test.tail)), test.tail...)
+		if got := incompleteTail(value); got != test.want {
+			t.Fatal("strict byte predicate changed")
+		}
+		if test.want > 0 && !utf8.Valid(value[:len(value)-test.want]) {
+			t.Fatal("candidate prefix is not valid UTF-8")
+		}
+	}
+}
+
+func assertResultPrivacy(t *testing.T, result repairResult) {
+	t.Helper()
+	data, err := json.Marshal(result)
+	if err != nil || len(data) > 4096 || bytes.Contains(data, []byte("PRIVATE_PAYLOAD_MARKER")) ||
+		bytes.Contains(data, []byte("/home/")) || bytes.Contains(data, []byte("attachment_id")) {
+		t.Fatal("repair output escaped fixed aggregate schema")
+	}
+}
+
+type workflowStep struct {
+	Name string         `yaml:"name"`
+	ID   string         `yaml:"id"`
+	Uses string         `yaml:"uses"`
+	If   string         `yaml:"if"`
+	Run  string         `yaml:"run"`
+	With map[string]any `yaml:"with"`
+	Env  map[string]any `yaml:"env"`
+}
+
+type workflowJob struct {
+	If          string            `yaml:"if"`
+	Needs       string            `yaml:"needs"`
+	Timeout     int               `yaml:"timeout-minutes"`
+	Permissions map[string]string `yaml:"permissions"`
+	Concurrency map[string]any    `yaml:"concurrency"`
+	Steps       []workflowStep    `yaml:"steps"`
+}
+
+type workflowDocument struct {
+	On          map[string]any         `yaml:"on"`
+	Permissions map[string]string      `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+func readWorkflow(t *testing.T) (workflowDocument, []byte) {
+	t.Helper()
+	var raw []byte
+	var err error
+	for _, prefix := range []string{".", ".."} {
+		raw, err = os.ReadFile(filepath.Join(prefix, ".github/workflows/repair-discord-cache.yml"))
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document workflowDocument
+	if yaml.Unmarshal(raw, &document) != nil {
+		t.Fatal("workflow is not valid YAML")
+	}
+	return document, raw
+}
+
+func stepScript(t *testing.T, document workflowDocument, id string) string {
+	t.Helper()
+	for _, step := range document.Jobs["repair"].Steps {
+		if step.ID == id {
+			return step.With["script"].(string)
+		}
+	}
+	t.Fatal("expected workflow script missing")
+	return ""
+}
+
+func runNode(t *testing.T, program string, args ...string) ([]byte, error) {
+	t.Helper()
+	binary := os.Getenv("NODE_BINARY")
+	if binary == "" {
+		binary = "node"
+	}
+	command := exec.Command(binary, append([]string{"-e", program}, args...)...)
+	command.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + t.TempDir()}
+	return command.CombinedOutput()
+}
+
+func TestWorkflowContract(t *testing.T) {
+	document, raw := readWorkflow(t)
+	if len(document.On) != 3 || document.On["pull_request"] == nil || document.On["push"] == nil ||
+		document.On["workflow_dispatch"] == nil || len(document.Jobs) != 2 ||
+		!reflect.DeepEqual(document.Permissions, map[string]string{"contents": "read"}) {
+		t.Fatal("workflow trigger/permission boundary widened")
+	}
+	paths := []any{".github/workflows/repair-discord-cache.yml", "scripts/repair_discord_cache.go",
+		"scripts/repair_discord_cache_test.go", "go.mod", "go.sum", "internal/store/**", "internal/share/**",
+		".github/workflows/publish-discord-backup.yml", ".github/workflows/discord-backup-report.yml"}
+	for _, event := range []string{"pull_request", "push"} {
+		trigger := document.On[event].(map[string]any)
+		if !reflect.DeepEqual(trigger["paths"], paths) ||
+			(event == "push" && !reflect.DeepEqual(trigger["branches"], []any{"main"})) {
+			t.Fatal("explicit helper validation path coverage changed")
+		}
+	}
+	repair := document.Jobs["repair"]
+	if repair.Needs != "validate" || repair.Timeout != 60 ||
+		!reflect.DeepEqual(repair.Concurrency, map[string]any{"group": "discord-backup-repo", "cancel-in-progress": false, "queue": "max"}) {
+		t.Fatal("writer admission or shared queue changed")
+	}
+	for _, guard := range []string{"github.event_name == 'workflow_dispatch'", "github.ref == 'refs/heads/main'",
+		"github.actor == 'vincentkoc'", "github.triggering_actor == 'vincentkoc'",
+		"github.run_attempt == '1'", "inputs.root_durable_ack == true", "needs.validate.result == 'success'"} {
+		if !strings.Contains(repair.If, guard) {
+			t.Fatal("data job guard missing")
+		}
+	}
+	validation := document.Jobs["validate"]
+	if validation.Concurrency != nil {
+		t.Fatal("read-only validation acquired the writer group")
+	}
+	var proof string
+	for _, step := range validation.Steps {
+		proof += step.Run
+		if strings.Contains(step.Uses, "cache") {
+			t.Fatal("validation may access app caches")
+		}
+	}
+	for _, command := range []string{"go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go",
+		"go test -count=1 -race scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go",
+		"go vet scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go", "go build -trimpath",
+		"git diff --exit-code -- go.mod go.sum"} {
+		if !strings.Contains(proof, command) {
+			t.Fatal("explicit-file helper CI proof missing")
+		}
+	}
+	for _, forbidden := range []string{"secrets.", "upload-artifact", "schedule:", "workflow_run:", "pull_request_target:",
+		"always()", "cache/save@", "cache/restore@", "git push", "go run ./cmd/", "sudo ", "/rerun", "/cancel"} {
+		if bytes.Contains(raw, []byte(forbidden)) {
+			t.Fatal("forbidden maintenance route")
+		}
+	}
+	wrappers, guards := []string{}, []string{}
+	saveIndex, helperIndex, gateIndex := -1, -1, -1
+	for index, step := range repair.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") && step.With["persist-credentials"] != false {
+			t.Fatal("checkout retained credentials")
+		}
+		if strings.HasPrefix(step.Uses, "actions/setup-go@") && step.With["cache"] != false {
+			t.Fatal("setup-go enabled save hooks")
+		}
+		if step.ID == "helper" {
+			helperIndex = index
+		}
+		if step.ID == "save-gate" {
+			gateIndex = index
+		}
+		if step.ID == "save" {
+			saveIndex = index
+			if !strings.Contains(step.If, "steps.helper.outputs.cache_ready == 'true'") ||
+				!strings.Contains(step.If, "steps.save-gate.outcome == 'success'") {
+				t.Fatal("save escaped helper/current-winner gates")
+			}
+		}
+		if step.ID == "lookup" || step.ID == "restore" || step.ID == "save" {
+			wrappers = append(wrappers, step.With["script"].(string))
+		}
+		if step.Env["PHASE"] != nil {
+			guards = append(guards, step.With["script"].(string))
+		}
+	}
+	if len(wrappers) != 3 || wrappers[0] != wrappers[1] || wrappers[0] != wrappers[2] ||
+		len(guards) != 4 || guards[0] != guards[1] || guards[0] != guards[2] || guards[0] != guards[3] ||
+		helperIndex < 0 || gateIndex <= helperIndex || saveIndex <= gateIndex {
+		t.Fatal("shared guarded restore/save route drifted")
+	}
+}
+
+func fixtureInputs() map[string]any {
+	version := sha256.Sum256([]byte(".discrawl-ci/discrawl.db|.discrawl-ci/discrawl.db-shm|.discrawl-ci/discrawl.db-wal|zstd-without-long|1.0"))
+	cache, _ := json.Marshal(map[string]any{"id": 42, "key": "discrawl-discord-db-Linux-main-100-1",
+		"ref": "refs/heads/main", "version": hex.EncodeToString(version[:]),
+		"created_at": "2026-01-01T00:00:00.000000000Z", "size_in_bytes": 1024})
+	return map[string]any{"expected_sha": strings.Repeat("a", 40), "cache_identity": string(cache),
+		"backup_run_id": "200", "backup_run_attempt": "1", "backup_source_sha": strings.Repeat("b", 40),
+		"backup_artifact_id": "300", "backup_artifact_digest": "sha256:" + strings.Repeat("c", 64),
+		"backup_ciphertext_sha256": strings.Repeat("d", 64), "root_durable_ack": true}
+}
+
+func TestContextGuards(t *testing.T) {
+	document, _ := readWorkflow(t)
+	script := stepScript(t, document, "context")
+	for _, scenario := range []string{"valid", "ack", "actor", "triggering-actor", "attempt", "event", "ref", "sha",
+		"workflow-sha", "workflow-ref", "debug", "unknown", "missing", "malformed-cache", "private-hash", "source-key-nonnumeric"} {
+		t.Run(scenario, func(t *testing.T) {
+			input := fixtureInputs()
+			env := map[string]string{
+				"GITHUB_REPOSITORY": "openclaw/discrawl", "RUNNER_OS": "Linux", "GITHUB_EVENT_NAME": "workflow_dispatch",
+				"GITHUB_REF": "refs/heads/main", "GITHUB_RUN_ATTEMPT": "1", "GITHUB_ACTOR": "vincentkoc",
+				"TRIGGERING_ACTOR": "vincentkoc", "GITHUB_SHA": strings.Repeat("a", 40), "EXPECTED_SHA": strings.Repeat("a", 40),
+				"WORKFLOW_SHA": strings.Repeat("a", 40), "WORKFLOW_REF": "openclaw/discrawl/.github/workflows/repair-discord-cache.yml@refs/heads/main",
+			}
+			switch scenario {
+			case "ack":
+				input["root_durable_ack"] = false
+			case "actor":
+				env["GITHUB_ACTOR"] = "other"
+			case "triggering-actor":
+				env["TRIGGERING_ACTOR"] = "other"
+			case "attempt":
+				env["GITHUB_RUN_ATTEMPT"] = "2"
+			case "event":
+				env["GITHUB_EVENT_NAME"] = "pull_request"
+			case "ref":
+				env["GITHUB_REF"] = "refs/heads/maintenance/example"
+			case "sha":
+				env["GITHUB_SHA"] = strings.Repeat("e", 40)
+			case "workflow-sha":
+				env["WORKFLOW_SHA"] = strings.Repeat("e", 40)
+			case "workflow-ref":
+				env["WORKFLOW_REF"] = "other"
+			case "debug":
+				env["RUNNER_DEBUG"] = "1"
+			case "unknown", "private-hash":
+				input["private_hash"] = "PRIVATE_PAYLOAD_MARKER"
+			case "missing":
+				delete(input, "backup_ciphertext_sha256")
+			case "malformed-cache":
+				input["cache_identity"] = "PRIVATE_PAYLOAD_MARKER"
+			case "source-key-nonnumeric":
+				var cache map[string]any
+				if json.Unmarshal([]byte(input["cache_identity"].(string)), &cache) != nil {
+					t.Fatal("synthetic cache input invalid")
+				}
+				cache["key"] = "discrawl-discord-db-Linux-main-unexpected"
+				raw, _ := json.Marshal(cache)
+				input["cache_identity"] = string(raw)
+			}
+			raw, _ := json.Marshal(input)
+			env["DISPATCH_INPUTS"] = string(raw)
+			payload, _ := json.Marshal(env)
+			program := `const env=JSON.parse(globalThis.process.argv[1]),failed=[];
+const process={env},core={setFailed:value=>failed.push(value)};
+` + script + `
+globalThis.process.stdout.write(JSON.stringify(failed));`
+			output, err := runNode(t, program, string(payload))
+			want := `["execution_context"]`
+			if scenario == "valid" {
+				want = "[]"
+			}
+			if err != nil || string(output) != want || bytes.Contains(output, []byte("PRIVATE_PAYLOAD_MARKER")) {
+				t.Fatal("context guard accepted unsafe input or leaked details")
+			}
+		})
+	}
+}
+
+func TestMetadataWinnerAndSaveReadback(t *testing.T) {
+	document, _ := readWorkflow(t)
+	script := stepScript(t, document, "before")
+	for _, scenario := range []string{"before", "copy", "save", "after", "main-drift", "newer-winner", "last-access",
+		"incomplete", "duplicate", "tie", "cache-drift", "backup-failed", "artifact-mismatch", "artifact-expired",
+		"active-writer", "new-key-exists", "save-warning-no-cache", "bad-new-version", "old-new-time",
+		"pending-normal", "queued-normal", "waiting-normal", "requested-normal", "queued-writer", "after-queued-publisher",
+		"validation-running", "validation-only", "writer-missing", "jobs-incomplete", "jobs-next-page", "jobs-duplicate",
+		"jobs-wrong-attempt", "jobs-wrong-run", "jobs-wrong-source", "jobs-unknown", "jobs-unknown-status",
+		"run-attempt-invalid", "jobs-error", "newer-nonnumeric-winner", "older-nonnumeric-key"} {
+		t.Run(scenario, func(t *testing.T) {
+			payload, _ := json.Marshal(fixtureInputs())
+			program := `const input=JSON.parse(globalThis.process.argv[1]),scenario=globalThis.process.argv[2];
+const expected=JSON.parse(input.cache_identity),created="2026-01-02T00:00:00.000000000Z";
+const saved={...expected,id:43,key:"discrawl-discord-db-Linux-main-400-1",created_at:created};
+const phase=["after","after-queued-publisher","save-warning-no-cache","bad-new-version","old-new-time"].includes(scenario)?"after":
+  ["copy","save"].includes(scenario)?scenario:"before";
+const env={DISPATCH_INPUTS:JSON.stringify(input),GITHUB_RUN_ID:"400",GITHUB_RUN_ATTEMPT:"1",GITHUB_SHA:input.expected_sha,PHASE:phase};
+let caches=[{...expected}];
+if(phase==="after"&&scenario!=="save-warning-no-cache")caches.push(saved);
+if(scenario==="main-drift")env.GITHUB_SHA="different";
+if(scenario==="newer-winner")caches.push({...saved,key:"discrawl-discord-db-Linux-main-350-1"});
+if(scenario==="newer-nonnumeric-winner")caches.push({...saved,key:"discrawl-discord-db-Linux-main-unexpected"});
+if(scenario==="older-nonnumeric-key")caches.push({...expected,id:44,key:"discrawl-discord-db-Linux-main-legacy",
+  created_at:"2025-01-01T00:00:00.000000000Z"});
+if(scenario==="last-access")caches[0].last_accessed_at="2099-01-01T00:00:00Z";
+if(scenario==="duplicate")caches.push({...expected});
+if(scenario==="tie")caches.push({...expected,id:44,key:"discrawl-discord-db-Linux-main-150-1"});
+if(scenario==="cache-drift")caches[0].size_in_bytes++;
+if(scenario==="new-key-exists")caches.push(saved);
+if(scenario==="bad-new-version")saved.version="different";
+if(scenario==="old-new-time")saved.created_at="2025-01-01T00:00:00Z";
+const waiting={"pending-normal":"pending","queued-normal":"queued","waiting-normal":"waiting",
+  "requested-normal":"requested","after-queued-publisher":"queued"};
+const repairRun=["validation-running","validation-only","writer-missing"].includes(scenario);
+const hasOther=Object.hasOwn(waiting,scenario)||repairRun||scenario.startsWith("jobs-")||
+  ["active-writer","queued-writer","run-attempt-invalid"].includes(scenario);
+const other={id:999,status:waiting[scenario]||"in_progress",run_attempt:scenario==="run-attempt-invalid"?0:2,
+  head_sha:"e".repeat(40)};
+const writer={id:1001,run_id:999,run_attempt:2,head_sha:other.head_sha,
+  name:repairRun?"Manually acknowledged repair and cache install":"publish",
+  status:scenario==="active-writer"?"in_progress":"queued"};
+let jobs=[writer],jobRequests=0;
+if(repairRun)jobs.unshift({...writer,id:1000,name:"Repair helper synthetic validation",
+  status:scenario==="writer-missing"?"completed":"in_progress"});
+if(["validation-only","writer-missing"].includes(scenario))jobs.pop();
+if(scenario==="jobs-duplicate")jobs.push({...writer});
+if(scenario==="jobs-wrong-attempt")writer.run_attempt=1;
+if(scenario==="jobs-wrong-run")writer.run_id=998;
+if(scenario==="jobs-wrong-source")writer.head_sha="f".repeat(40);
+if(scenario==="jobs-unknown")writer.name="unknown";
+if(scenario==="jobs-unknown-status")writer.status="unknown";
+const github={rest:{
+  git:{getRef:async()=>({data:{object:{sha:input.expected_sha}}})},
+  actions:{
+    getWorkflowRun:async({run_id})=>({data:run_id===400?
+      {head_sha:input.expected_sha,run_attempt:1,run_started_at:"2026-01-01T12:00:00Z"}:
+      {id:200,repository:{full_name:"openclaw/discrawl"},head_sha:input.backup_source_sha,run_attempt:1,
+       status:"completed",conclusion:scenario==="backup-failed"?"failure":"success",path:".github/workflows/publish-discord-backup.yml"}}),
+    getArtifact:async()=>({data:{id:300,workflow_run:{id:200,head_sha:input.backup_source_sha},expired:scenario==="artifact-expired",
+      size_in_bytes:1024,digest:scenario==="artifact-mismatch"?"different":input.backup_artifact_digest}}),
+    listWorkflowRuns:async({workflow_id,status})=>{
+      const found=hasOther&&status===other.status&&workflow_id===(repairRun?"repair-discord-cache.yml":"publish-discord-backup.yml");
+      return {data:{total_count:found?1:0,workflow_runs:found?[other]:[]},headers:{}};
+    },
+    listJobsForWorkflowRunAttempt:async({run_id,attempt_number,per_page,page})=>{
+      jobRequests++;
+      if(run_id!==999||attempt_number!==2||per_page!==100||page!==1||scenario==="jobs-error")
+        throw new Error("PRIVATE_PAYLOAD_MARKER");
+      return {data:{total_count:jobs.length+(scenario==="jobs-incomplete"?1:0),jobs},
+        headers:scenario==="jobs-next-page"?{link:'placeholder; rel="next"'}:{}};
+    },
+    getActionsCacheList:async()=>({data:{total_count:caches.length+(scenario==="incomplete"?1:0),actions_caches:caches},headers:{}})
+  }
+}};
+const failed=[],outputs=[],info=[];
+const process={env},core={setFailed:x=>failed.push(x),setOutput:(k,v)=>outputs.push([k,v]),info:x=>info.push(x)};
+(async()=>{` + script + `})().then(()=>globalThis.process.stdout.write(JSON.stringify({failed,outputs,info,jobRequests})));`
+			output, err := runNode(t, program, string(payload), scenario)
+			var result struct {
+				Failed      []string `json:"failed"`
+				Outputs     [][]any  `json:"outputs"`
+				Info        []string `json:"info"`
+				JobRequests int      `json:"jobRequests"`
+			}
+			valid := scenario == "before" || scenario == "copy" || scenario == "save" || scenario == "after" || scenario == "last-access" ||
+				scenario == "pending-normal" || scenario == "queued-normal" || scenario == "waiting-normal" || scenario == "requested-normal" ||
+				scenario == "queued-writer" || scenario == "after-queued-publisher" || scenario == "validation-running" ||
+				scenario == "validation-only" || scenario == "older-nonnumeric-key"
+			if err != nil || json.Unmarshal(output, &result) != nil || valid != (len(result.Failed) == 0) ||
+				bytes.Contains(output, []byte("PRIVATE_PAYLOAD_MARKER")) {
+				t.Fatalf("metadata disposition incorrect for %s", scenario)
+			}
+			jobLookup := strings.HasPrefix(scenario, "jobs-") || scenario == "active-writer" || scenario == "queued-writer" ||
+				scenario == "validation-running" || scenario == "validation-only" || scenario == "writer-missing"
+			expectedRequests := 0
+			if jobLookup {
+				expectedRequests = 1
+			}
+			if result.JobRequests != expectedRequests {
+				t.Fatal("writer inspection did not use one complete exact-attempt job response")
+			}
+			after := scenario == "save-warning-no-cache" || scenario == "bad-new-version" || scenario == "old-new-time"
+			if !valid && (!reflect.DeepEqual(result.Failed, []string{"metadata_gate"}) ||
+				len(result.Info) != map[bool]int{false: 0, true: 1}[after] || len(result.Outputs) != 0) {
+				t.Fatal("failed metadata emitted success outputs")
+			}
+		})
+	}
+}
+
+func TestRestoreCapacityAdmission(t *testing.T) {
+	document, _ := readWorkflow(t)
+	var run string
+	contextIndex, buildIndex, lookupIndex := -1, -1, -1
+	for index, step := range document.Jobs["repair"].Steps {
+		switch step.ID {
+		case "context":
+			contextIndex = index
+		case "build":
+			buildIndex, run = index, step.Run
+		case "lookup":
+			lookupIndex = index
+		}
+	}
+	_, check, start := strings.Cut(run, "<<'CAPACITY'\n")
+	check, _, end := strings.Cut(check, "\nCAPACITY\n")
+	if !start || !end || contextIndex < 0 || buildIndex <= contextIndex || lookupIndex <= buildIndex ||
+		strings.Index(run, "go build ") > strings.Index(run, "<<'CAPACITY'") ||
+		!strings.Contains(run, `env -i PATH=/usr/bin:/bin DISPATCH_INPUTS="$DISPATCH_INPUTS" "$NODE_BINARY" <<'CAPACITY'`) {
+		t.Fatal("validated measured capacity admission moved before build or after private access")
+	}
+	const gib = uint64(1 << 30)
+	for _, test := range []struct {
+		name string
+		k    uint64
+		free uint64
+		want bool
+	}{
+		{"below", gib, 19*gib - 1, false},
+		{"at", gib, 19 * gib, true},
+		{"above", gib, 19*gib + 1, true},
+		{"larger-cache", 2 * gib, 19 * gib, false},
+		{"largest-cache", 8 * gib, 26 * gib, true},
+		{"zero-cache", 0, 18 * gib, false},
+		{"oversized-cache", 8*gib + 1, 27 * gib, false},
+		{"unsafe-integer", 1 << 53, 1 << 54, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := fixtureInputs()
+			cache, _ := json.Marshal(map[string]uint64{"size_in_bytes": test.k})
+			input["cache_identity"] = string(cache)
+			raw, _ := json.Marshal(input)
+			program := `process.env.DISPATCH_INPUTS=process.argv[1];
+require("node:fs").statfsSync=(path,options)=>{
+  if(path!=="."||options.bigint!==true)throw new Error();
+  return {bsize:1n,bavail:BigInt(process.argv[2])};
+};
+` + check
+			output, err := runNode(t, program, string(raw), strconv.FormatUint(test.free, 10))
+			if (err == nil) != test.want || (test.want && len(output) != 0) ||
+				(!test.want && string(output) != "::error::restore_capacity\n") {
+				t.Fatal("compressed cache plus source/reserve capacity boundary changed")
+			}
+		})
+	}
+}
+
+func TestContainedSaveAndRestore(t *testing.T) {
+	document, _ := readWorkflow(t)
+	script := stepScript(t, document, "lookup")
+	function, _, ok := strings.Cut(script, "\ntry {\n")
+	if !ok {
+		t.Fatal("capture function boundary missing")
+	}
+	for _, scenario := range []string{"restore", "save", "save-warning", "save-output", "command", "nonzero", "capture-cap", "timeout"} {
+		t.Run(scenario, func(t *testing.T) {
+			directory := t.TempDir()
+			entry := filepath.Join(directory, "entry.cjs")
+			child := `const fs=require("node:fs"),mode=` + strconv.Quote(scenario) + `;
+process.stdout.write("PRIVATE_PAYLOAD_MARKER\n");process.stderr.write("PRIVATE_PAYLOAD_MARKER\n");
+if(process.env.GITHUB_TOKEN||process.env.EXTRA_PROVIDER_TOKEN||process.env.NODE_OPTIONS)process.exit(3);
+if(process.env.INPUT_PATH!==".discrawl-ci/discrawl.db\n.discrawl-ci/discrawl.db-shm\n.discrawl-ci/discrawl.db-wal")process.exit(3);
+if(mode==="restore"){
+  for(const [name,value]of[["cache-primary-key",process.env.INPUT_KEY],["cache-matched-key",process.env.INPUT_KEY],["cache-hit","true"]])
+    fs.appendFileSync(process.env.GITHUB_OUTPUT,name+"="+value+"\n");
+}else if(process.env["INPUT_LOOKUP-ONLY"]!==undefined)process.exit(3);
+if(mode==="save-warning")process.stdout.write("warning: no cache saved");
+if(mode==="save-output")fs.appendFileSync(process.env.GITHUB_OUTPUT,"cache-id=123\n");
+if(mode==="command")fs.appendFileSync(process.env.GITHUB_ENV,"INJECTED=PRIVATE_PAYLOAD_MARKER\n");
+if(mode==="nonzero")process.exit(2);
+if(mode==="capture-cap")process.stdout.write("PRIVATE_PAYLOAD_MARKER".repeat(1000));
+if(mode==="timeout")setInterval(()=>{},1000);
+`
+			if os.WriteFile(entry, []byte(child), 0600) != nil {
+				t.Fatal("synthetic child creation failed")
+			}
+			payload, _ := json.Marshal(map[string]any{"directory": directory, "entry": entry, "scenario": scenario})
+			program := `const input=JSON.parse(process.argv[1]);
+Object.assign(process.env,{GITHUB_TOKEN:"placeholder",EXTRA_PROVIDER_TOKEN:"placeholder",NODE_OPTIONS:"not-forwarded"});
+` + function + `
+containedCache({node:process.execPath,entry:input.entry,workspace:input.directory,privateRoot:input.directory,
+key:"discrawl-discord-db-Linux-main-100-1",lookupOnly:"false",saveOnly:input.scenario!=="restore",
+timeoutMs:500,streamCap:input.scenario==="capture-cap"?64:4096,commandCap:1024})
+.then(output=>process.stdout.write(JSON.stringify({ok:true,output})))
+.catch(error=>process.stdout.write(JSON.stringify({ok:false,error:error.message})));`
+			output, err := runNode(t, program, string(payload))
+			if err != nil || bytes.Contains(output, []byte("PRIVATE_PAYLOAD_MARKER")) || len(output) > 1024 {
+				t.Fatal("stock action output escaped capture")
+			}
+			var result struct {
+				OK     bool              `json:"ok"`
+				Output map[string]string `json:"output"`
+				Error  string            `json:"error"`
+			}
+			if json.Unmarshal(output, &result) != nil {
+				t.Fatal("capture output invalid")
+			}
+			valid := scenario == "restore" || scenario == "save" || scenario == "save-warning"
+			if result.OK != valid || ((scenario == "save" || scenario == "save-warning") && len(result.Output) != 0) {
+				t.Fatal("capture/save output contract violated")
+			}
+		})
+	}
+}
+
+func TestHelperAdmissionPrivacy(t *testing.T) {
+	result := runRepair(context.Background(), []string{"PRIVATE_PAYLOAD_MARKER"})
+	if result.Complete || result.Error != "arguments" {
+		t.Fatal("invalid invocation accepted")
+	}
+	assertResultPrivacy(t, result)
+}
+
+func TestStandaloneSaveBoundary(t *testing.T) {
+	document, _ := readWorkflow(t)
+	_, boundary, ok := strings.Cut(stepScript(t, document, "save"), "\ntry {\n")
+	if !ok {
+		t.Fatal("save boundary missing")
+	}
+	for _, scenario := range []string{"valid", "wal", "empty", "symlink", "hardlink", "mode", "wrong-key", "unsafe-size"} {
+		t.Run(scenario, func(t *testing.T) {
+			program := `const fs=require("node:fs"),os=require("node:os"),path=require("node:path");
+const scenario=process.argv[1],workspace=fs.mkdtempSync(path.join(os.tmpdir(),"repair-save-test-"));
+const root=path.join(workspace,".discrawl-ci"),db=path.join(root,"discrawl.db");
+fs.mkdirSync(root,{mode:0o700});fs.writeFileSync(db,"synthetic",{mode:0o600});
+if(scenario==="wal")fs.writeFileSync(path.join(root,"discrawl.db-wal"),"synthetic");
+if(scenario==="empty")fs.truncateSync(db,0);
+if(scenario==="mode")fs.chmodSync(db,0o644);
+if(scenario==="symlink"){fs.unlinkSync(db);fs.symlinkSync("missing",db);}
+if(scenario==="hardlink")fs.linkSync(db,path.join(workspace,"other"));
+if(scenario==="unsafe-size"){
+  const lstat=fs.lstatSync;
+  fs.lstatSync=(file,...args)=>{const info=lstat(file,...args);if(file===db)info.size=10*1024**3+1;return info;};
+}
+Object.assign(process.env,{CACHE_MODE:"save",NODE_BINARY:process.execPath,GITHUB_WORKSPACE:workspace,
+  GITHUB_RUN_ID:"400",EXPECTED_KEY:"discrawl-discord-db-Linux-main-"+(scenario==="wrong-key"?"399":"400")+"-1"});
+const failed=[];let called=0;
+const core={setFailed:value=>failed.push(value),setOutput:()=>{throw new Error("unexpected output");}};
+async function containedCache(){called++;return {};}
+(async()=>{try {
+` + boundary + `
+})().then(()=>{fs.rmSync(workspace,{recursive:true});process.stdout.write(JSON.stringify({called,failed}));});`
+			output, err := runNode(t, program, scenario)
+			var result struct {
+				Called int      `json:"called"`
+				Failed []string `json:"failed"`
+			}
+			if err != nil || json.Unmarshal(output, &result) != nil ||
+				(scenario == "valid" && (result.Called != 1 || len(result.Failed) != 0)) ||
+				(scenario != "valid" && (result.Called != 0 || !reflect.DeepEqual(result.Failed, []string{"restore_context"}))) {
+				t.Fatal("unsafe standalone directory or key reached cache save")
+			}
+		})
+	}
+}
+
+func TestHelperOutputGate(t *testing.T) {
+	document, _ := readWorkflow(t)
+	var run string
+	for _, step := range document.Jobs["repair"].Steps {
+		if step.ID == "helper" {
+			run = step.Run
+		}
+	}
+	_, validator, ok := strings.Cut(run, "<<'JS'\n")
+	validator, _, end := strings.Cut(validator, "\nJS\n")
+	if !ok || !end {
+		t.Fatal("helper output validator missing")
+	}
+	for _, scenario := range []string{"valid", "failure", "exit", "counts", "unknown", "malformed", "oversized", "private-error"} {
+		t.Run(scenario, func(t *testing.T) {
+			result := repairResult{SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
+				Complete: true, Stage: "cache_ready", Error: "none", OriginalUnchanged: true,
+				ChangedCells: 46, RemovedBytes: 67, Tails: [3]int64{25, 21, 0}, ExportRows: map[string]int64{}}
+			for _, table := range share.SnapshotTables {
+				result.ExportRows[table] = 1
+			}
+			result.ExportRows["message_attachments"] = expectedCells
+			if scenario == "failure" || scenario == "private-error" {
+				result.Complete, result.Stage, result.Error = false, "export", "strict_export"
+				if scenario == "private-error" {
+					result.Error = "PRIVATE_PAYLOAD_MARKER"
+				}
+			}
+			if scenario == "counts" {
+				result.ChangedCells--
+			}
+			raw, _ := json.Marshal(result)
+			switch scenario {
+			case "unknown":
+				raw = append(raw[:len(raw)-1], []byte(`,"private":"PRIVATE_PAYLOAD_MARKER"}`)...)
+			case "malformed":
+				raw = []byte("PRIVATE_PAYLOAD_MARKER")
+			case "oversized":
+				raw = bytes.Repeat([]byte("PRIVATE_PAYLOAD_MARKER"), 300)
+			}
+			directory := t.TempDir()
+			if os.WriteFile(filepath.Join(directory, "result.json"), raw, 0600) != nil {
+				t.Fatal("synthetic result creation failed")
+			}
+			program := `process.env.PRIVATE_TEMP=process.argv[1];process.env.HELPER_STATUS=process.argv[2];` + validator
+			status := "0"
+			if scenario == "exit" {
+				status = "1"
+			}
+			output, err := runNode(t, program, directory, status)
+			if (err == nil) != (scenario == "valid") || bytes.Contains(output, []byte("PRIVATE_PAYLOAD_MARKER")) {
+				t.Fatal("failed helper result admitted or private output escaped")
+			}
+			if scenario != "valid" && scenario != "failure" && string(output) != "::error::repair_output\n" {
+				t.Fatal("invalid result did not emit the fixed error")
+			}
+			if scenario == "failure" && string(output) != `{"schema_version":1,"complete":false,"stage":"export","error":"strict_export","original_unchanged":true}`+"\n" {
+				t.Fatal("helper failure was not reduced to fixed public fields")
+			}
+		})
+	}
+}
+
+func TestSchemaLiteralWhitespaceNotIgnored(t *testing.T) {
+	changed := strings.Replace(attachmentDDL, "default ''", "default ' '", 1)
+	if normalizedDDL(changed) == normalizedDDL(attachmentDDL) {
+		t.Fatal("schema literal changed during normalization")
+	}
+}
+
+func TestCheckpointAdmissionBeforeWALConsolidation(t *testing.T) {
+	for _, scenario := range []string{"reject-checkpoint", "reject-journal", "admit"} {
+		t.Run(scenario, func(t *testing.T) {
+			original := filepath.Join(t.TempDir(), "fixture.db")
+			db, err := sql.Open("sqlite", original)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			db.SetMaxOpenConns(1)
+			if _, err = db.Exec(`PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;
+				CREATE TABLE fixture(value BLOB); INSERT INTO fixture VALUES(zeroblob(131072));`); err != nil {
+				t.Fatal(err)
+			}
+			logical, err := logicalBytes(context.Background(), db)
+			if err != nil {
+				t.Fatal(err)
+			}
+			scratch := t.TempDir()
+			file := filepath.Join(scratch, "working.db")
+			before := map[string][]byte{}
+			for _, suffix := range []string{"", "-wal", "-shm"} {
+				body, err := os.ReadFile(original + suffix)
+				if err != nil || os.WriteFile(file+suffix, body, 0600) != nil {
+					t.Fatal("synthetic WAL copy failed")
+				}
+				before[suffix] = body
+			}
+			if int64(len(before[""])) >= logical {
+				t.Fatal("fixture does not require checkpoint growth")
+			}
+			var requests []int64
+			admit := func(directory string, additional int64) error {
+				if directory != scratch {
+					t.Fatal("capacity checked on the wrong filesystem")
+				}
+				requests = append(requests, additional)
+				if len(requests) == 1 && scenario == "reject-checkpoint" ||
+					len(requests) == 2 && scenario == "reject-journal" {
+					return errors.New("capacity")
+				}
+				return nil
+			}
+			working, size, err := prepareWorkingDatabase(context.Background(), file, scratch, admit)
+			if scenario == "admit" {
+				if err != nil || working == nil || size != logical {
+					t.Fatal("measured checkpoint admission failed")
+				}
+				working.Close()
+			} else if err == nil || err.Error() != "capacity" || working != nil {
+				t.Fatal("failed capacity admission retained a writable DB")
+			}
+			expected := []int64{logical, 2 * logical}
+			if scenario == "reject-checkpoint" {
+				expected = expected[:1]
+				for _, suffix := range []string{"", "-wal"} {
+					after, err := os.ReadFile(file + suffix)
+					if err != nil || !bytes.Equal(after, before[suffix]) {
+						t.Fatal("rejected admission checkpointed the copied WAL")
+					}
+				}
+			}
+			if !reflect.DeepEqual(requests, expected) {
+				t.Fatal("checkpoint or journal/backup headroom was not admitted")
+			}
+		})
+	}
+}

--- a/scripts/repair_discord_cache_test.go
+++ b/scripts/repair_discord_cache_test.go
@@ -27,7 +27,7 @@ import (
 func repairFixture(t *testing.T, wal bool) (string, *sql.DB) {
 	t.Helper()
 	source := filepath.Join(t.TempDir(), ".discrawl-ci")
-	if err := os.Mkdir(source, 0700); err != nil {
+	if err := os.Mkdir(source, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	s, err := store.Open(context.Background(), filepath.Join(source, inputNames[0]))
@@ -195,8 +195,10 @@ func TestExactRepairStandaloneExport(t *testing.T) {
 }
 
 func TestRepairRollbackAndAdmission(t *testing.T) {
-	for _, scenario := range []string{"interior", "overlong", "surrogate", "continuation", "wrong-length",
-		"missing-candidate", "blob", "schema", "trigger", "text-index", "cas", "mid-transaction"} {
+	for _, scenario := range []string{
+		"interior", "overlong", "surrogate", "continuation", "wrong-length",
+		"missing-candidate", "blob", "schema", "trigger", "text-index", "cas", "mid-transaction",
+	} {
 		t.Run(scenario, func(t *testing.T) {
 			source, db := repairFixture(t, false)
 			switch scenario {
@@ -307,8 +309,12 @@ func TestStrictCandidateClassifier(t *testing.T) {
 		tail []byte
 		want int
 	}{
-		{[]byte{0xc2}, 1}, {[]byte{0xe2, 0x82}, 2}, {[]byte{0xf0, 0x9f, 0x92}, 3},
-		{[]byte{0xff}, 0}, {[]byte{0xc0, 0xaf}, 0}, {[]byte{0xed, 0xa0, 0x80}, 0},
+		{[]byte{0xc2}, 1},
+		{[]byte{0xe2, 0x82}, 2},
+		{[]byte{0xf0, 0x9f, 0x92}, 3},
+		{[]byte{0xff}, 0},
+		{[]byte{0xc0, 0xaf}, 0},
+		{[]byte{0xed, 0xa0, 0x80}, 0},
 		{[]byte("\ufffd"), 0},
 	} {
 		value := append(bytes.Repeat([]byte("a"), 8192-len(test.tail)), test.tail...)
@@ -404,9 +410,11 @@ func TestWorkflowContract(t *testing.T) {
 		!reflect.DeepEqual(document.Permissions, map[string]string{"contents": "read"}) {
 		t.Fatal("workflow trigger/permission boundary widened")
 	}
-	paths := []any{".github/workflows/repair-discord-cache.yml", "scripts/repair_discord_cache.go",
+	paths := []any{
+		".github/workflows/repair-discord-cache.yml", "scripts/repair_discord_cache.go",
 		"scripts/repair_discord_cache_test.go", "go.mod", "go.sum", "internal/store/**", "internal/share/**",
-		".github/workflows/publish-discord-backup.yml", ".github/workflows/discord-backup-report.yml"}
+		".github/workflows/publish-discord-backup.yml", ".github/workflows/discord-backup-report.yml",
+	}
 	for _, event := range []string{"pull_request", "push"} {
 		trigger := document.On[event].(map[string]any)
 		if !reflect.DeepEqual(trigger["paths"], paths) ||
@@ -419,9 +427,11 @@ func TestWorkflowContract(t *testing.T) {
 		!reflect.DeepEqual(repair.Concurrency, map[string]any{"group": "discord-backup-repo", "cancel-in-progress": false, "queue": "max"}) {
 		t.Fatal("writer admission or shared queue changed")
 	}
-	for _, guard := range []string{"github.event_name == 'workflow_dispatch'", "github.ref == 'refs/heads/main'",
+	for _, guard := range []string{
+		"github.event_name == 'workflow_dispatch'", "github.ref == 'refs/heads/main'",
 		"github.actor == 'vincentkoc'", "github.triggering_actor == 'vincentkoc'",
-		"github.run_attempt == '1'", "inputs.root_durable_ack == true", "needs.validate.result == 'success'"} {
+		"github.run_attempt == '1'", "inputs.root_durable_ack == true", "needs.validate.result == 'success'",
+	} {
 		if !strings.Contains(repair.If, guard) {
 			t.Fatal("data job guard missing")
 		}
@@ -437,16 +447,20 @@ func TestWorkflowContract(t *testing.T) {
 			t.Fatal("validation may access app caches")
 		}
 	}
-	for _, command := range []string{"go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go",
+	for _, command := range []string{
+		"go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go",
 		"go test -count=1 -race scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go",
 		"go vet scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go", "go build -trimpath",
-		"git diff --exit-code -- go.mod go.sum"} {
+		"git diff --exit-code -- go.mod go.sum",
+	} {
 		if !strings.Contains(proof, command) {
 			t.Fatal("explicit-file helper CI proof missing")
 		}
 	}
-	for _, forbidden := range []string{"secrets.", "upload-artifact", "schedule:", "workflow_run:", "pull_request_target:",
-		"always()", "cache/save@", "cache/restore@", "git push", "go run ./cmd/", "sudo ", "/rerun", "/cancel"} {
+	for _, forbidden := range []string{
+		"secrets.", "upload-artifact", "schedule:", "workflow_run:", "pull_request_target:",
+		"always()", "cache/save@", "cache/restore@", "git push", "go run ./cmd/", "sudo ", "/rerun", "/cancel",
+	} {
 		if bytes.Contains(raw, []byte(forbidden)) {
 			t.Fatal("forbidden maintenance route")
 		}
@@ -489,20 +503,26 @@ func TestWorkflowContract(t *testing.T) {
 
 func fixtureInputs() map[string]any {
 	version := sha256.Sum256([]byte(".discrawl-ci/discrawl.db|.discrawl-ci/discrawl.db-shm|.discrawl-ci/discrawl.db-wal|zstd-without-long|1.0"))
-	cache, _ := json.Marshal(map[string]any{"id": 42, "key": "discrawl-discord-db-Linux-main-100-1",
+	cache, _ := json.Marshal(map[string]any{
+		"id": 42, "key": "discrawl-discord-db-Linux-main-100-1",
 		"ref": "refs/heads/main", "version": hex.EncodeToString(version[:]),
-		"created_at": "2026-01-01T00:00:00.000000000Z", "size_in_bytes": 1024})
-	return map[string]any{"expected_sha": strings.Repeat("a", 40), "cache_identity": string(cache),
+		"created_at": "2026-01-01T00:00:00.000000000Z", "size_in_bytes": 1024,
+	})
+	return map[string]any{
+		"expected_sha": strings.Repeat("a", 40), "cache_identity": string(cache),
 		"backup_run_id": "200", "backup_run_attempt": "1", "backup_source_sha": strings.Repeat("b", 40),
 		"backup_artifact_id": "300", "backup_artifact_digest": "sha256:" + strings.Repeat("c", 64),
-		"backup_ciphertext_sha256": strings.Repeat("d", 64), "root_durable_ack": true}
+		"backup_ciphertext_sha256": strings.Repeat("d", 64), "root_durable_ack": true,
+	}
 }
 
 func TestContextGuards(t *testing.T) {
 	document, _ := readWorkflow(t)
 	script := stepScript(t, document, "context")
-	for _, scenario := range []string{"valid", "ack", "actor", "triggering-actor", "attempt", "event", "ref", "sha",
-		"workflow-sha", "workflow-ref", "debug", "unknown", "missing", "malformed-cache", "private-hash", "source-key-nonnumeric"} {
+	for _, scenario := range []string{
+		"valid", "ack", "actor", "triggering-actor", "attempt", "event", "ref", "sha",
+		"workflow-sha", "workflow-ref", "debug", "unknown", "missing", "malformed-cache", "private-hash", "source-key-nonnumeric",
+	} {
 		t.Run(scenario, func(t *testing.T) {
 			input := fixtureInputs()
 			env := map[string]string{
@@ -569,13 +589,15 @@ globalThis.process.stdout.write(JSON.stringify(failed));`
 func TestMetadataWinnerAndSaveReadback(t *testing.T) {
 	document, _ := readWorkflow(t)
 	script := stepScript(t, document, "before")
-	for _, scenario := range []string{"before", "copy", "save", "after", "main-drift", "newer-winner", "last-access",
+	for _, scenario := range []string{
+		"before", "copy", "save", "after", "main-drift", "newer-winner", "last-access",
 		"incomplete", "duplicate", "tie", "cache-drift", "backup-failed", "artifact-mismatch", "artifact-expired",
 		"active-writer", "new-key-exists", "save-warning-no-cache", "bad-new-version", "old-new-time",
 		"pending-normal", "queued-normal", "waiting-normal", "requested-normal", "queued-writer", "after-queued-publisher",
 		"validation-running", "validation-only", "writer-missing", "jobs-incomplete", "jobs-next-page", "jobs-duplicate",
 		"jobs-wrong-attempt", "jobs-wrong-run", "jobs-wrong-source", "jobs-unknown", "jobs-unknown-status",
-		"run-attempt-invalid", "jobs-error", "newer-nonnumeric-winner", "older-nonnumeric-key"} {
+		"run-attempt-invalid", "jobs-error", "newer-nonnumeric-winner", "older-nonnumeric-key",
+	} {
 		t.Run(scenario, func(t *testing.T) {
 			payload, _ := json.Marshal(fixtureInputs())
 			program := `const input=JSON.parse(globalThis.process.argv[1]),scenario=globalThis.process.argv[2];
@@ -760,7 +782,7 @@ if(mode==="nonzero")process.exit(2);
 if(mode==="capture-cap")process.stdout.write("PRIVATE_PAYLOAD_MARKER".repeat(1000));
 if(mode==="timeout")setInterval(()=>{},1000);
 `
-			if os.WriteFile(entry, []byte(child), 0600) != nil {
+			if os.WriteFile(entry, []byte(child), 0o600) != nil {
 				t.Fatal("synthetic child creation failed")
 			}
 			payload, _ := json.Marshal(map[string]any{"directory": directory, "entry": entry, "scenario": scenario})
@@ -858,9 +880,11 @@ func TestHelperOutputGate(t *testing.T) {
 	}
 	for _, scenario := range []string{"valid", "failure", "exit", "counts", "unknown", "malformed", "oversized", "private-error"} {
 		t.Run(scenario, func(t *testing.T) {
-			result := repairResult{SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
+			result := repairResult{
+				SchemaVersion: 1, Scope: "restored_cache.message_attachments.text_content",
 				Complete: true, Stage: "cache_ready", Error: "none", OriginalUnchanged: true,
-				ChangedCells: 46, RemovedBytes: 67, Tails: [3]int64{25, 21, 0}, ExportRows: map[string]int64{}}
+				ChangedCells: 46, RemovedBytes: 67, Tails: [3]int64{25, 21, 0}, ExportRows: map[string]int64{},
+			}
 			for _, table := range share.SnapshotTables {
 				result.ExportRows[table] = 1
 			}
@@ -884,7 +908,7 @@ func TestHelperOutputGate(t *testing.T) {
 				raw = bytes.Repeat([]byte("PRIVATE_PAYLOAD_MARKER"), 300)
 			}
 			directory := t.TempDir()
-			if os.WriteFile(filepath.Join(directory, "result.json"), raw, 0600) != nil {
+			if os.WriteFile(filepath.Join(directory, "result.json"), raw, 0o600) != nil {
 				t.Fatal("synthetic result creation failed")
 			}
 			program := `process.env.PRIVATE_TEMP=process.argv[1];process.env.HELPER_STATUS=process.argv[2];` + validator
@@ -936,7 +960,7 @@ func TestCheckpointAdmissionBeforeWALConsolidation(t *testing.T) {
 			before := map[string][]byte{}
 			for _, suffix := range []string{"", "-wal", "-shm"} {
 				body, err := os.ReadFile(original + suffix)
-				if err != nil || os.WriteFile(file+suffix, body, 0600) != nil {
+				if err != nil || os.WriteFile(file+suffix, body, 0o600) != nil {
 					t.Fatal("synthetic WAL copy failed")
 				}
 				before[suffix] = body


### PR DESCRIPTION
## Summary

- Add a manual, backup-first workflow for one narrowly scoped Discord cache
  repair. PR and main-push events run synthetic validation only.
- Require the reviewed main SHA, explicit durable-backup acknowledgement,
  exact immutable cache identity, current-winner checks and shared writer
  serialization before the data job can proceed. Allow serialized waiters
  under the held lock while rejecting active or ambiguous writer jobs.
  Include every eligible literal-prefix cache key in winner selection.
- Provide a helper limited to the 46 approved incomplete attachment-text
  tails in one byte-CAS transaction on a disposable copy, removing exactly
  67 bytes while preserving original files and all other stored values.
- Require integrity/reopen verification and a full strict eight-table
  snapshot export before a coherent standalone DB can be saved under a
  new main-scoped cache key. Require cache metadata readback after save.

## Validation

All helper tests use synthetic temporary databases. The build-ignore files
are explicitly named by this workflow; ordinary app tests are not used as
proof that this helper ran.
The full suite below passed before the sole checkpoint-admission review
fix. The final candidate then passed the affected repair/WAL/export tests
and new admission regression, including race, plus vet/build. Unchanged
workflow proof was reused.

- `go test -count=1 scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go`: passed.
- `go test -count=1 -race scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go`: passed.
- `go vet scripts/repair_discord_cache.go scripts/repair_discord_cache_test.go`: passed.
- `go build -trimpath ... scripts/repair_discord_cache.go`: passed.
- `gofumpt v0.11.0`: format check passed after the mechanical octal-literal
  and layout correction identified by hosted lint. No behavioral change.
- Unchanged module files and diff checks: passed.
- Parsed workflow/context/metadata/save-boundary/output privacy fixtures: passed.
- After the checkpoint-admission review fix, focused repair/WAL/export
  regressions, race, vet and build passed.
- The subsequent workflow-only contract batch passed focused tests/race,
  vet and parsed workflow checks, including measured compressed-cache plus
  source/reserve capacity admission before restore.

The installed actionlint version predates `concurrency.queue` and rejects
that key only. The documented `queue: max` is retained; all other actionlint
checks pass with that one unsupported-key diagnostic excluded. Structured
tests assert the exact native queue contract.

Local review found one checkpoint-admission ordering issue. It was fixed
and regression-tested; the scoped follow-up review is clear.
The independently reviewed queued-writer/prefix-winner/capacity batch also
passed one scoped follow-up review with no remaining actionable findings.

## Execution Boundary

This PR does not execute a repair or authorize a dispatch. A separate
operator decision is required after durable authenticated backup readback,
review/CI clearance and final main verification. No cache data, private
hashes, keys or values are included here. No existing publisher/reporter,
dependency, product schema/API or release workflow is changed.

A completed save is not proof of runtime recovery. Normal publisher and
producer-receipt verification remain separate; releases remain held.

## Related Groundwork

- https://github.com/openclaw/discrawl/pull/201
- https://github.com/openclaw/discrawl/pull/203
- https://github.com/openclaw/discrawl/pull/205
