### PR TITLE
fix(ci): accept migrated attachment schemas in cache repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.14.1 - 2026-09-09
 
+- Accept the application's legacy migrated attachment column order in the backup-first repair helper while retaining exact schema and repair safeguards.
 - Add a manually gated, backup-first maintenance workflow for narrowly scoped attachment text repair, with strict snapshot validation before installing a new Actions database cache.
 - Keep extracted attachment text within its byte limit without splitting valid UTF-8 characters, and identify invalid admitted attachment columns in contents-free export errors without changing stored data or weakening snapshot validation.
 - Limit disposable Discord backup clones to current main and required descendants, without fetching tagged history.

--- a/scripts/repair_discord_cache.go
+++ b/scripts/repair_discord_cache.go
@@ -48,6 +48,15 @@ const attachmentDDL = `CREATE TABLE message_attachments (
 	fetched_at text, fetch_status text not null default '', fetch_error text not null default '',
 	updated_at text not null)`
 
+// The app's six ALTER ADD migrations append media fields after updated_at.
+const migratedAttachmentDDL = `CREATE TABLE message_attachments (
+	attachment_id text primary key, message_id text not null, guild_id text not null,
+	channel_id text not null, author_id text, filename text not null, content_type text,
+	size integer not null default 0, url text, proxy_url text, text_content text not null default '',
+	updated_at text not null, media_path text, content_sha256 text,
+	content_size integer not null default 0, fetched_at text,
+	fetch_status text not null default '', fetch_error text not null default '')`
+
 var attachmentColumns = []string{
 	"attachment_id", "message_id", "guild_id", "channel_id", "author_id", "filename",
 	"content_type", "size", "url", "proxy_url", "text_content", "media_path",
@@ -524,7 +533,8 @@ func validateSchema(ctx context.Context, conn *sql.Conn) error {
 		kind != "table" || conn.QueryRowContext(ctx, "SELECT count(*) FROM main.sqlite_schema WHERE type='trigger' AND tbl_name='message_attachments'").Scan(&triggers) != nil || triggers != 0 {
 		return errors.New("schema")
 	}
-	if normalizedDDL(ddl) != normalizedDDL(attachmentDDL) {
+	normalized := normalizedDDL(ddl)
+	if normalized != normalizedDDL(attachmentDDL) && normalized != normalizedDDL(migratedAttachmentDDL) {
 		return errors.New("schema")
 	}
 	rows, err := conn.QueryContext(ctx, "PRAGMA main.index_list(message_attachments)")

--- a/scripts/repair_discord_cache_test.go
+++ b/scripts/repair_discord_cache_test.go
@@ -26,16 +26,46 @@ import (
 
 func repairFixture(t *testing.T, wal bool) (string, *sql.DB) {
 	t.Helper()
+	return repairFixtureLayout(t, wal, false)
+}
+
+func repairFixtureLayout(t *testing.T, wal, migrated bool) (string, *sql.DB) {
+	t.Helper()
 	source := filepath.Join(t.TempDir(), ".discrawl-ci")
 	if err := os.Mkdir(source, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	s, err := store.Open(context.Background(), filepath.Join(source, inputNames[0]))
+	dbPath := filepath.Join(source, inputNames[0])
+	if migrated {
+		legacy, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Seed the app's pre-media schema, then let store.Open run its migrations.
+		_, createErr := legacy.Exec(`create table message_attachments (
+			attachment_id text primary key, message_id text not null, guild_id text not null,
+			channel_id text not null, author_id text, filename text not null, content_type text,
+			size integer not null default 0, url text, proxy_url text, text_content text not null default '',
+			updated_at text not null)`)
+		closeErr := legacy.Close()
+		if createErr != nil || closeErr != nil {
+			t.Fatal("synthetic legacy schema creation failed")
+		}
+	}
+	s, err := store.Open(context.Background(), dbPath)
 	if err != nil {
 		t.Fatal("synthetic store creation failed")
 	}
 	db := s.DB()
 	t.Cleanup(func() { s.Close() })
+	if migrated {
+		var ddl string
+		if db.QueryRow(`SELECT sql FROM sqlite_schema WHERE name='message_attachments'`).Scan(&ddl) != nil ||
+			normalizedDDL(ddl) != normalizedDDL(migratedAttachmentDDL) ||
+			normalizedDDL(ddl) == normalizedDDL(attachmentDDL) {
+			t.Fatal("app migration did not produce the exact legacy layout")
+		}
+	}
 	tx, err := db.Begin()
 	if err != nil {
 		t.Fatal(err)
@@ -145,7 +175,14 @@ func logicalTable(t *testing.T, db *sql.DB, table string) []byte {
 }
 
 func TestExactRepairStandaloneExport(t *testing.T) {
-	source, db := repairFixture(t, false)
+	t.Run("fresh", func(t *testing.T) { testExactRepairStandaloneExport(t, false) })
+	t.Run("migrated", func(t *testing.T) { testExactRepairStandaloneExport(t, true) })
+}
+
+func testExactRepairStandaloneExport(t *testing.T, migrated bool) {
+	t.Helper()
+	source, db := repairFixtureLayout(t, false, migrated)
+	expectedAttachments := attachmentFixtureState(t, db, true)
 	before := map[string][]byte{}
 	for _, table := range share.SnapshotTables {
 		if table != "message_attachments" {
@@ -172,6 +209,9 @@ func TestExactRepairStandaloneExport(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ready.Close()
+	if !bytes.Equal(expectedAttachments, attachmentFixtureState(t, ready, false)) {
+		t.Fatal("attachment fields or storage classes changed beyond the exact suffixes")
+	}
 	var count, removed int64
 	if err = ready.QueryRow(`SELECT count(*),sum(8192-length(CAST(text_content AS BLOB)))
 		FROM message_attachments WHERE CAST(attachment_id AS INTEGER)<46`).Scan(&count, &removed); err != nil ||
@@ -191,6 +231,99 @@ func TestExactRepairStandaloneExport(t *testing.T) {
 	}
 	if _, err = os.Stat(filepath.Join(scratch, "originals", inputNames[0])); err != nil {
 		t.Fatal("original file set was not retained")
+	}
+}
+
+func attachmentFixtureState(t *testing.T, db *sql.DB, repaired bool) []byte {
+	t.Helper()
+	var selectColumns []string
+	for _, column := range attachmentColumns {
+		selectColumns = append(selectColumns, "typeof("+column+")", "CAST("+column+" AS BLOB)")
+	}
+	rows, err := db.Query("SELECT " + strings.Join(selectColumns, ",") +
+		" FROM message_attachments ORDER BY CAST(attachment_id AS INTEGER)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var state [][]any
+	for row := 0; rows.Next(); row++ {
+		values := make([]any, len(selectColumns))
+		destinations := make([]any, len(values))
+		for index := range destinations {
+			destinations[index] = &values[index]
+		}
+		if rows.Scan(destinations...) != nil {
+			t.Fatal("synthetic attachment state read failed")
+		}
+		if repaired && row < 46 {
+			text := values[21].([]byte)
+			drop := 1
+			if row >= 25 {
+				drop = 2
+			}
+			values[21] = text[:len(text)-drop]
+		}
+		state = append(state, values)
+	}
+	if rows.Err() != nil {
+		t.Fatal("synthetic attachment state incomplete")
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}
+
+func TestAttachmentSchemaLayouts(t *testing.T) {
+	for name, ddl := range map[string]string{"fresh": attachmentDDL, "migrated": migratedAttachmentDDL} {
+		t.Run(name, func(t *testing.T) {
+			for _, scenario := range []string{
+				"accepted", "constraint", "default", "extra-column", "trigger",
+				"partial-index", "expression-index", "text-index",
+			} {
+				t.Run(scenario, func(t *testing.T) {
+					db, err := sql.Open("sqlite", ":memory:")
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer db.Close()
+					definition := ddl
+					switch scenario {
+					case "constraint":
+						definition = strings.Replace(definition, "filename text not null", "filename text", 1)
+					case "default":
+						definition = strings.Replace(definition, "fetch_status text not null default ''",
+							"fetch_status text not null default 'changed'", 1)
+					}
+					if _, err = db.Exec(definition); err != nil {
+						t.Fatal(err)
+					}
+					statement := map[string]string{
+						"extra-column":     "ALTER TABLE message_attachments ADD COLUMN unexpected TEXT",
+						"trigger":          "CREATE TRIGGER unexpected AFTER UPDATE ON message_attachments BEGIN SELECT 1; END",
+						"partial-index":    "CREATE INDEX unexpected ON message_attachments(message_id) WHERE size > 0",
+						"expression-index": "CREATE INDEX unexpected ON message_attachments(length(message_id))",
+						"text-index":       "CREATE INDEX unexpected ON message_attachments(text_content)",
+					}[scenario]
+					if statement != "" {
+						if _, err = db.Exec(statement); err != nil {
+							t.Fatal(err)
+						}
+					}
+					conn, err := db.Conn(context.Background())
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer conn.Close()
+					err = validateSchema(context.Background(), conn)
+					if (err == nil) != (scenario == "accepted") {
+						t.Fatal("exact schema admission changed")
+					}
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The backup-first repair helper accepted only the attachment table layout created by a fresh installation. Databases upgraded through the application's six attachment-media ALTER statements retain `updated_at` before the added columns, so the exact schema guard rejected that supported layout.

- Accept one exact app-migrated DDL alternative alongside the existing fresh DDL.
- Keep normalization, encoding, trigger and index guards, repair limits, byte-CAS updates and strict export unchanged.
- Exercise the real app migration in temporary synthetic fixtures, verify full repair/export and field/storage-class preservation for both layouts, and reject changed constraints/defaults, extra columns, triggers and unsafe indexes.

Related: https://github.com/openclaw/discrawl/pull/206

## Validation

- Before the fix, the app-migrated synthetic repair fixture reproduced `stage=repair`, `error=schema`.
- All 139 explicit helper tests passed, including both fresh and migrated full repair/export cases.
- All 139 explicit helper race tests passed.
- Explicit-file `go vet` and `go build -trimpath` passed.
- Gofumpt v0.11.0 and `git diff --check` passed.
- `GOWORK=off`, read-only modules; no `go.mod`, `go.sum` or workflow changes.

This PR changes source preparation only. It does not run a repair, install a cache or establish successful publication; those operations remain separately gated.
