### PR TITLE
feat(report): publish deterministic Discord field notes

### DIFF
--- a/.github/workflows/discord-backup-report.yml
+++ b/.github/workflows/discord-backup-report.yml
@@ -74,13 +74,14 @@ jobs:
           printf 'db_path = "%s"\n' "$DB" > "$CONFIG"
           go run ./cmd/discrawl --config "$CONFIG" subscribe --repo "$BACKUP_REPO" "$BACKUP_REMOTE"
           git -C "$BACKUP_REPO" pull --ff-only origin main
-          go run ./cmd/discrawl --config "$CONFIG" report --published --readme "$BACKUP_REPO/README.md"
-          if git -C "$BACKUP_REPO" diff --quiet README.md; then
-            echo "README already up to date"
+          go run ./cmd/discrawl --config "$CONFIG" report --published --field-notes --readme "$BACKUP_REPO/README.md"
+          report_paths=(README.md reports/latest-field-notes.md reports/latest-field-notes.json)
+          git -C "$BACKUP_REPO" add -- "${report_paths[@]}"
+          if git -C "$BACKUP_REPO" diff --cached --quiet -- "${report_paths[@]}"; then
+            echo "Report and field notes already up to date"
             exit 0
           fi
-          git -C "$BACKUP_REPO" add README.md
-          git -C "$BACKUP_REPO" commit -m "docs: update discord activity report"
+          git -C "$BACKUP_REPO" commit --only -m "docs: update discord activity report and field notes" -- "${report_paths[@]}"
           git -C "$BACKUP_REPO" push
 
       - name: Save Discord DB cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, explicit timestamp and coverage limits, and filtered-publication cleanup.
+- Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, separate markers preserving legacy narrative notes, explicit timestamp and coverage limits, and filtered-publication cleanup.
 
 ## 0.14.1 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, explicit timestamp and coverage limits, and filtered-publication cleanup.
+
 ## 0.14.1 - 2026-09-09
 
 - Accept the application's legacy migrated attachment column order in the backup-first repair helper while retaining exact schema and repair safeguards.

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -72,8 +72,9 @@ share repo already has a generated Discrawl `README.md` from an earlier
 unfiltered publish, filtered publish removes it before committing. Custom
 README files without Discrawl report markers are left alone.
 Producer-owned `reports/latest-field-notes.md` and `.json` are also removed
-by filtered publishing, even without a README. A README containing generated
-field-notes markers is removed too. Other reports and maintainer docs remain
+by filtered publishing, even without a README. A README containing either
+aggregate or legacy narrative field-notes markers is removed too; legacy notes
+are not exempt from the privacy guard. Other reports and maintainer docs remain
 untouched; ordinary unfiltered publication preserves the notes.
 
 ## What is published

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -71,6 +71,10 @@ does not apply those filters and would otherwise leak unfiltered totals. If the
 share repo already has a generated Discrawl `README.md` from an earlier
 unfiltered publish, filtered publish removes it before committing. Custom
 README files without Discrawl report markers are left alone.
+Producer-owned `reports/latest-field-notes.md` and `.json` are also removed
+by filtered publishing, even without a README. A README containing generated
+field-notes markers is removed too. Other reports and maintainer docs remain
+untouched; ordinary unfiltered publication preserves the notes.
 
 ## What is published
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -39,8 +39,13 @@ Every scheduled snapshot publish updates this block.
 
 The daily report workflow also generates `reports/latest-field-notes.md` and
 `reports/latest-field-notes.json` beside the README. A separate
-`discrawl-field-notes:start/end` marker block displays the Markdown notes.
-Both artifacts and the activity block use one report build.
+`discrawl-aggregate-field-notes:start/end` marker block displays the Markdown
+notes. Both artifacts and the activity block use one report build.
+
+These deterministic aggregates are distinct from historical AI-generated
+narratives inside `discrawl-field-notes:start/end` markers. Ordinary report
+writes preserve that legacy block byte for byte; they neither regenerate it nor
+call a model. The aggregate block is updated independently.
 
 Notes contain aggregate totals and the existing 24-hour, 7-day, and 30-day
 windows, not names, IDs, message content, topic inference, or model output.
@@ -57,7 +62,8 @@ neither recent nor empty results establish complete history.
 
 The two artifact paths are producer-owned. Keep maintainer documentation and
 manual notes elsewhere. Filtered publishing removes these broader-scope
-artifacts and generated README output rather than leaking unfiltered counts.
+artifacts and generated README output, including legacy narrative blocks,
+rather than leaking broader-scope content.
 Ordinary snapshot publishes preserve the notes; only a successful daily report
 generation refreshes them. A failed generation must not be committed.
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -7,12 +7,15 @@ Generates the Markdown activity block used by the shared backup repo README.
 ```bash
 discrawl report
 discrawl report --published --readme path/to/discord-backup/README.md
+discrawl report --published --field-notes --readme path/to/discord-backup/README.md
 ```
 
 ## Flags
 
 - `--readme <path>` - update the activity block in the given README file in place
 - `--published` - exclude local-only direct messages from all statistics and rankings
+- `--field-notes` - also write deterministic aggregate notes; requires
+  `--published` and `--readme`
 
 Local reports include direct messages by default, including with `--readme`.
 Use `--published` for a shared README. Private guild channels and threads remain
@@ -31,6 +34,32 @@ Deterministic README stats:
 - day / week / month activity
 
 Every scheduled snapshot publish updates this block.
+
+## Field notes
+
+The daily report workflow also generates `reports/latest-field-notes.md` and
+`reports/latest-field-notes.json` beside the README. A separate
+`discrawl-field-notes:start/end` marker block displays the Markdown notes.
+Both artifacts and the activity block use one report build.
+
+Notes contain aggregate totals and the existing 24-hour, 7-day, and 30-day
+windows, not names, IDs, message content, topic inference, or model output.
+Intervals anchor to the latest archived message, not necessarily the current
+time; the inclusive start and anchor timestamps are explicit. Attachment
+counts mean messages containing attachments, not attachment files.
+
+JSON version 1 records `generator: deterministic`, `scope: published-non-dm`,
+`coverage: unknown`, timestamps, totals, and windows. Timestamp status is
+`observed`, `empty`, `unavailable`, or `future`; unavailable/future timestamps
+have no age value. Empty/unavailable timestamps retain the existing report's
+generation-time fallback. Message timestamp age is not sync freshness, and
+neither recent nor empty results establish complete history.
+
+The two artifact paths are producer-owned. Keep maintainer documentation and
+manual notes elsewhere. Filtered publishing removes these broader-scope
+artifacts and generated README output rather than leaking unfiltered counts.
+Ordinary snapshot publishes preserve the notes; only a successful daily report
+generation refreshes them. A failed generation must not be committed.
 
 ## CI integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,4 +168,5 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
   `share.filter.exclude_channel_ids` accept Discord channel ids; exclusions win,
   and including a forum parent also includes its allowed public threads
 - filtered publishes cannot write generated README reports, and remove older
-  generated Discrawl share READMEs before committing
+  generated Discrawl share READMEs and the producer-owned
+  `reports/latest-field-notes.md` / `.json` artifacts before committing

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -201,9 +201,11 @@ Search archived Discord members.
 
 Show archive status and freshness.
 `,
-	"report": `Usage: discrawl report [--published] [--readme PATH]
+	"report": `Usage: discrawl report [--published] [--readme PATH] [--field-notes]
 
 Generate the archive activity report.
+--field-notes requires --published and --readme; writes aggregate Markdown/JSON
+notes under reports/ beside the README, with a separate README notes block.
 Local reports include direct messages by default. --published excludes direct
 messages, but still includes private guild content. --published rejects configured
 share filters.

--- a/internal/cli/report_commands.go
+++ b/internal/cli/report_commands.go
@@ -14,11 +14,15 @@ func (r *runtime) runReport(args []string) error {
 	fs.SetOutput(io.Discard)
 	readmePath := fs.String("readme", "", "")
 	published := fs.Bool("published", false, "")
+	fieldNotes := fs.Bool("field-notes", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("report takes no positional arguments"))
+	}
+	if *fieldNotes && (!*published || *readmePath == "") {
+		return usageErr(errors.New("report --field-notes requires --published and --readme"))
 	}
 	filter := share.FilterOptions{
 		PublicOnly:        r.cfg.Share.Filter.PublicOnly,
@@ -37,7 +41,12 @@ func (r *runtime) runReport(args []string) error {
 		return err
 	}
 	if *readmePath != "" {
-		if err := report.WriteReadme(*readmePath, section); err != nil {
+		if *fieldNotes {
+			err = report.WriteReadmeWithFieldNotes(*readmePath, section, activity)
+		} else {
+			err = report.WriteReadme(*readmePath, section)
+		}
+		if err != nil {
 			return err
 		}
 		return r.print(map[string]any{

--- a/internal/cli/report_privacy_test.go
+++ b/internal/cli/report_privacy_test.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/report"
 	"github.com/openclaw/discrawl/internal/store"
 	"github.com/stretchr/testify/require"
 )
@@ -48,6 +50,32 @@ func TestPublishedReportCLIAndPublishExcludeDirectMessages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, string(body), "dm-only-label")
 
+	out.Reset()
+	require.NoError(t, r.runReport([]string{"--published", "--field-notes", "--readme", sharedReadme}))
+	metadata, err := os.ReadFile(filepath.Join(dir, report.FieldNotesJSONPath))
+	require.NoError(t, err)
+	var notes report.FieldNotes
+	require.NoError(t, json.Unmarshal(metadata, &notes))
+	require.Equal(t, "published-non-dm", notes.Scope)
+	require.Equal(t, "unknown", notes.Coverage)
+	require.NotContains(t, string(metadata), "dm-only-label")
+	require.NotContains(t, string(metadata), "general")
+	require.NotContains(t, string(metadata), "2099-01-01")
+	markdown, err := os.ReadFile(filepath.Join(dir, report.FieldNotesMarkdownPath))
+	require.NoError(t, err)
+	require.Contains(t, string(markdown), notes.GeneratedAt.Format("2006-01-02T15:04:05Z07:00"))
+	require.NotContains(t, string(markdown), "general")
+	body, err = os.ReadFile(sharedReadme)
+	require.NoError(t, err)
+	require.Contains(t, string(body), string(bytes.TrimSpace(markdown)))
+	for _, args := range [][]string{
+		{"--field-notes"},
+		{"--field-notes", "--readme", sharedReadme},
+		{"--field-notes", "--published"},
+	} {
+		require.ErrorContains(t, r.runReport(args), "requires --published and --readme")
+	}
+
 	repo := filepath.Join(dir, "share")
 	remote := filepath.Join(dir, "remote.git")
 	runGit(t, dir, "init", "--bare", remote)
@@ -62,6 +90,65 @@ func TestPublishedReportCLIAndPublishExcludeDirectMessages(t *testing.T) {
 	r.cfg.Share.Filter.PublicOnly = true
 	require.NoError(t, r.runReport(nil), "share filters must not change the local default")
 	require.ErrorContains(t, r.runReport([]string{"--published", "--readme", sharedReadme}), "not supported with share filters")
+	require.ErrorContains(t, r.runReport([]string{"--published", "--field-notes", "--readme", sharedReadme}), "not supported with share filters")
+	unchanged, err := os.ReadFile(filepath.Join(dir, report.FieldNotesJSONPath))
+	require.NoError(t, err)
+	require.Equal(t, metadata, unchanged)
 	require.ErrorContains(t, r.runPublish([]string{"--repo", repo, "--remote", remote, "--no-commit", "--readme", publishReadme}), "not supported with share filters")
 	require.Contains(t, commandUsage["report"], "--published")
+}
+
+func TestFilteredPublishRemovesFieldNotesPreservesDocs(t *testing.T) {
+	for _, readmeMode := range []string{"activity-and-notes", "notes-only", "missing", "custom"} {
+		t.Run(readmeMode, func(t *testing.T) {
+			dir := t.TempDir()
+			remote := filepath.Join(dir, "remote.git")
+			repo := filepath.Join(dir, "publisher")
+			runGit(t, dir, "init", "--bare", remote)
+			s := seedCLIStore(t, filepath.Join(dir, "fixture.db"))
+			t.Cleanup(func() { _ = s.Close() })
+			cfg := config.Default()
+			cfg.DBPath = filepath.Join(dir, "fixture.db")
+			r := &runtime{ctx: t.Context(), cfg: cfg, store: s, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+			require.NoError(t, r.runPublish([]string{"--repo", repo, "--remote", remote, "--no-media"}))
+			runGit(t, repo, "config", "user.name", "Fixture")
+			runGit(t, repo, "config", "user.email", "fixture@example.invalid")
+			runGit(t, repo, "config", "commit.gpgsign", "false")
+			readme := filepath.Join(repo, "README.md")
+			require.NoError(t, r.runReport([]string{"--published", "--field-notes", "--readme", readme}))
+			switch readmeMode {
+			case "notes-only":
+				require.NoError(t, os.WriteFile(readme, []byte(report.FieldNotesStartMarker+"\nnotes\n"+report.FieldNotesEndMarker), 0o600))
+			case "missing":
+				require.NoError(t, os.Remove(readme))
+			case "custom":
+				require.NoError(t, os.WriteFile(readme, []byte("# Custom maintainer README\n"), 0o600))
+			}
+			for _, name := range []string{"AGENTS.md", "CONTRIBUTING.md", "reports/manual.md"} {
+				require.NoError(t, os.WriteFile(filepath.Join(repo, name), []byte("maintainer instructions\n"), 0o600))
+			}
+			runGit(t, repo, "add", ".")
+			runGit(t, repo, "commit", "-m", "test: notes and docs")
+			// Unfiltered publication must preserve both artifacts and docs.
+			require.NoError(t, r.runPublish([]string{"--repo", repo, "--remote", remote, "--no-media", "--push"}))
+			require.FileExists(t, filepath.Join(repo, report.FieldNotesJSONPath))
+			require.NoError(t, os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte("unrelated staged change\n"), 0o600))
+			runGit(t, repo, "add", "AGENTS.md")
+			// Exercise cleanup independently of README presence and repeat after
+			// --no-commit so exact deletions must be recovered from Git's index.
+			args := []string{"--repo", repo, "--remote", remote, "--no-media", "--include-channels", "c1"}
+			require.NoError(t, r.runPublish(append(args, "--no-commit")))
+			require.NoFileExists(t, filepath.Join(repo, report.FieldNotesMarkdownPath))
+			require.NoFileExists(t, filepath.Join(repo, report.FieldNotesJSONPath))
+			require.NoError(t, r.runPublish(append(args, "--push")))
+			for _, name := range []string{"AGENTS.md", "CONTRIBUTING.md", "reports/manual.md"} {
+				require.FileExists(t, filepath.Join(repo, name))
+			}
+			if readmeMode == "custom" {
+				require.FileExists(t, readme)
+			} else {
+				require.NoFileExists(t, readme)
+			}
+		})
+	}
 }

--- a/internal/cli/report_privacy_test.go
+++ b/internal/cli/report_privacy_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/openclaw/discrawl/internal/config"
@@ -141,13 +143,30 @@ func TestFilteredPublishRemovesFieldNotesPreservesDocs(t *testing.T) {
 			require.NoFileExists(t, filepath.Join(repo, report.FieldNotesMarkdownPath))
 			require.NoFileExists(t, filepath.Join(repo, report.FieldNotesJSONPath))
 			require.NoError(t, r.runPublish(append(args, "--push")))
+			remoteTree, err := exec.CommandContext(t.Context(), "git", "--git-dir", remote,
+				"ls-tree", "-r", "--name-only", "main").Output()
+			require.NoError(t, err)
+			publishedPaths := strings.Fields(string(remoteTree))
+			require.NotContains(t, publishedPaths, report.FieldNotesMarkdownPath)
+			require.NotContains(t, publishedPaths, report.FieldNotesJSONPath)
 			for _, name := range []string{"AGENTS.md", "CONTRIBUTING.md", "reports/manual.md"} {
 				require.FileExists(t, filepath.Join(repo, name))
+				require.Contains(t, publishedPaths, name)
 			}
+			publishedInstructions, err := exec.CommandContext(t.Context(), "git", "--git-dir", remote,
+				"show", "main:AGENTS.md").Output()
+			require.NoError(t, err)
+			require.Equal(t, "maintainer instructions\n", string(publishedInstructions))
+			staged, err := exec.CommandContext(t.Context(), "git", "-C", repo,
+				"diff", "--cached", "--name-only").Output()
+			require.NoError(t, err)
+			require.Contains(t, strings.Fields(string(staged)), "AGENTS.md")
 			if readmeMode == "custom" {
 				require.FileExists(t, readme)
+				require.Contains(t, publishedPaths, "README.md")
 			} else {
 				require.NoFileExists(t, readme)
+				require.NotContains(t, publishedPaths, "README.md")
 			}
 		})
 	}

--- a/internal/cli/report_privacy_test.go
+++ b/internal/cli/report_privacy_test.go
@@ -101,7 +101,7 @@ func TestPublishedReportCLIAndPublishExcludeDirectMessages(t *testing.T) {
 }
 
 func TestFilteredPublishRemovesFieldNotesPreservesDocs(t *testing.T) {
-	for _, readmeMode := range []string{"activity-and-notes", "notes-only", "missing", "custom"} {
+	for _, readmeMode := range []string{"activity-and-notes", "notes-only", "legacy-only", "legacy-and-aggregate", "missing", "custom"} {
 		t.Run(readmeMode, func(t *testing.T) {
 			dir := t.TempDir()
 			remote := filepath.Join(dir, "remote.git")
@@ -121,6 +121,12 @@ func TestFilteredPublishRemovesFieldNotesPreservesDocs(t *testing.T) {
 			switch readmeMode {
 			case "notes-only":
 				require.NoError(t, os.WriteFile(readme, []byte(report.FieldNotesStartMarker+"\nnotes\n"+report.FieldNotesEndMarker), 0o600))
+			case "legacy-only", "legacy-and-aggregate":
+				body := report.LegacyFieldNotesStartMarker + "\nsynthetic historical narrative\n" + report.LegacyFieldNotesEndMarker
+				if readmeMode == "legacy-and-aggregate" {
+					body += "\n" + report.FieldNotesStartMarker + "\naggregate notes\n" + report.FieldNotesEndMarker
+				}
+				require.NoError(t, os.WriteFile(readme, []byte(body), 0o600))
 			case "missing":
 				require.NoError(t, os.Remove(readme))
 			case "custom":

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -184,7 +184,8 @@ func removeGeneratedReadmeForFilteredPublish(repoPath string) (bool, error) {
 	text := string(body)
 	hasReport := strings.Contains(text, report.StartMarker) && strings.Contains(text, report.EndMarker)
 	hasNotes := strings.Contains(text, report.FieldNotesStartMarker) && strings.Contains(text, report.FieldNotesEndMarker)
-	if !hasReport && !hasNotes {
+	hasLegacyNotes := strings.Contains(text, report.LegacyFieldNotesStartMarker) && strings.Contains(text, report.LegacyFieldNotesEndMarker)
+	if !hasReport && !hasNotes && !hasLegacyNotes {
 		return false, nil
 	}
 	err = os.Remove(readmePath)

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -170,6 +170,9 @@ func (r *runtime) runPublish(args []string) error {
 }
 
 func removeGeneratedReadmeForFilteredPublish(repoPath string) (bool, error) {
+	if err := report.RemoveFieldNotes(repoPath); err != nil {
+		return false, err
+	}
 	readmePath := filepath.Join(repoPath, "README.md")
 	body, err := os.ReadFile(readmePath)
 	if errors.Is(err, os.ErrNotExist) {
@@ -179,7 +182,9 @@ func removeGeneratedReadmeForFilteredPublish(repoPath string) (bool, error) {
 		return false, err
 	}
 	text := string(body)
-	if !strings.Contains(text, report.StartMarker) || !strings.Contains(text, report.EndMarker) {
+	hasReport := strings.Contains(text, report.StartMarker) && strings.Contains(text, report.EndMarker)
+	hasNotes := strings.Contains(text, report.FieldNotesStartMarker) && strings.Contains(text, report.FieldNotesEndMarker)
+	if !hasReport && !hasNotes {
 		return false, nil
 	}
 	err = os.Remove(readmePath)

--- a/internal/report/field_notes.go
+++ b/internal/report/field_notes.go
@@ -1,0 +1,220 @@
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	FieldNotesStartMarker  = "<!-- discrawl-field-notes:start -->"
+	FieldNotesEndMarker    = "<!-- discrawl-field-notes:end -->"
+	FieldNotesMarkdownPath = "reports/latest-field-notes.md"
+	FieldNotesJSONPath     = "reports/latest-field-notes.json"
+)
+
+type FieldNotes struct {
+	Version                 int                `json:"version"`
+	Generator               string             `json:"generator"`
+	Scope                   string             `json:"scope"`
+	Coverage                string             `json:"coverage"`
+	GeneratedAt             time.Time          `json:"generated_at"`
+	LatestMessageAt         *time.Time         `json:"latest_message_at"`
+	LatestMessageAgeSeconds *int64             `json:"latest_message_age_seconds"`
+	WindowAnchorAt          time.Time          `json:"window_anchor_at"`
+	TimestampStatus         string             `json:"timestamp_status"`
+	Totals                  FieldNotesTotals   `json:"totals"`
+	Windows                 []FieldNotesWindow `json:"windows"`
+}
+
+type FieldNotesTotals struct {
+	Messages int `json:"messages"`
+	Channels int `json:"channels"`
+	Members  int `json:"member_records"`
+}
+
+type FieldNotesWindow struct {
+	Since                   time.Time `json:"since"`
+	Messages                int       `json:"messages"`
+	ActiveAuthors           int       `json:"active_authors"`
+	ActiveChannels          int       `json:"active_channels"`
+	MessagesWithAttachments int       `json:"messages_with_attachments"`
+}
+
+// RenderFieldNotes consumes the same published report as the activity block.
+// It deliberately excludes rankings, names, identifiers and message content.
+func RenderFieldNotes(activity ActivityReport) ([]byte, []byte, error) {
+	notes := FieldNotes{
+		Version: 1, Generator: "deterministic", Scope: "published-non-dm",
+		Coverage: "unknown", GeneratedAt: activity.GeneratedAt.UTC(),
+		WindowAnchorAt: activity.GeneratedAt.UTC(), TimestampStatus: "unavailable",
+		Totals:  FieldNotesTotals{activity.TotalMessages, activity.TotalChannels, activity.TotalMembers},
+		Windows: make([]FieldNotesWindow, 0, len(activity.Windows)),
+	}
+	if activity.TotalMessages == 0 {
+		notes.TimestampStatus = "empty"
+	} else if !activity.LatestMessageAt.IsZero() {
+		latest := activity.LatestMessageAt.UTC()
+		notes.LatestMessageAt = &latest
+		notes.WindowAnchorAt = latest
+		notes.TimestampStatus = "observed"
+		if latest.After(notes.GeneratedAt) {
+			notes.TimestampStatus = "future"
+		} else {
+			age := int64(notes.GeneratedAt.Sub(latest) / time.Second)
+			notes.LatestMessageAgeSeconds = &age
+		}
+	}
+	for _, window := range activity.Windows {
+		notes.Windows = append(notes.Windows, FieldNotesWindow{
+			Since: window.Since.UTC(), Messages: window.Messages,
+			ActiveAuthors: window.ActiveAuthors, ActiveChannels: window.ActiveChannels,
+			MessagesWithAttachments: window.Attachments,
+		})
+	}
+	body, err := json.MarshalIndent(notes, "", "  ")
+	if err != nil {
+		return nil, nil, err
+	}
+	var md strings.Builder
+	fmt.Fprintf(&md, "## Field Notes\n\nGenerated at: %s\n\n", notes.GeneratedAt.Format(time.RFC3339))
+	md.WriteString("Deterministic aggregate observations.\n")
+	md.WriteString("Scope: published non-DM archive; private guild channels may be included.\n")
+	md.WriteString("Coverage: unknown. These counts do not establish complete history or a successful sync.\n\n")
+	fmt.Fprintf(&md, "Observed archive: %d messages, %d recorded channels, %d member records.\n\n",
+		notes.Totals.Messages, notes.Totals.Channels, notes.Totals.Members)
+	switch notes.TimestampStatus {
+	case "empty":
+		md.WriteString("No archived non-DM messages observed; this does not establish that Discord had no activity.\n")
+		md.WriteString("Intervals use the report generation time because there is no latest message.\n")
+	case "unavailable":
+		md.WriteString("Latest archived message timestamp unavailable. Intervals use the report generation time fallback; invalid message timestamps may be omitted from counts.\n")
+	case "future":
+		fmt.Fprintf(&md, "Latest archived message: %s, later than report generation. Timestamp age is unavailable; intervals retain this future anchor.\n",
+			notes.LatestMessageAt.Format(time.RFC3339))
+	default:
+		fmt.Fprintf(&md, "Latest archived message: %s (%d seconds before generation). This is message timestamp age, not sync freshness.\n",
+			notes.LatestMessageAt.Format(time.RFC3339), *notes.LatestMessageAgeSeconds)
+	}
+	md.WriteString("\n### Anchored Activity\n\n")
+	fmt.Fprintf(&md, "Intervals end at %s, not necessarily the current time. Start boundaries are inclusive.\n\n",
+		notes.WindowAnchorAt.Format(time.RFC3339))
+	for _, window := range notes.Windows {
+		fmt.Fprintf(&md, "- Since %s: %d messages from %d active authors across %d active channels; %d messages contain attachments",
+			window.Since.Format(time.RFC3339), window.Messages, window.ActiveAuthors,
+			window.ActiveChannels, window.MessagesWithAttachments)
+		if window.Messages > 0 {
+			fmt.Fprintf(&md, " (%.1f%% of messages)", 100*float64(window.MessagesWithAttachments)/float64(window.Messages))
+		}
+		md.WriteString(".\n")
+	}
+	return []byte(md.String()), append(body, '\n'), nil
+}
+
+func UpdateFieldNotes(readme []byte, section string) ([]byte, error) {
+	text := string(readme)
+	start, end := strings.Index(text, FieldNotesStartMarker), strings.Index(text, FieldNotesEndMarker)
+	replacement := FieldNotesStartMarker + "\n" + strings.TrimSpace(section) + "\n" + FieldNotesEndMarker
+	if start == -1 && end == -1 {
+		return []byte(strings.TrimRight(text, "\n") + "\n\n" + replacement + "\n"), nil
+	}
+	if start < 0 || end < start || strings.Count(text, FieldNotesStartMarker) != 1 ||
+		strings.Count(text, FieldNotesEndMarker) != 1 {
+		return nil, errors.New("invalid field notes README markers")
+	}
+	return []byte(text[:start] + replacement + text[end+len(FieldNotesEndMarker):]), nil
+}
+
+func checkFieldNotesPath(root *os.Root, name string, directory bool) error {
+	info, err := root.Lstat(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if (directory && !info.IsDir()) || (!directory && !info.Mode().IsRegular()) {
+		return errors.New("field notes output must use regular files and directories")
+	}
+	return nil
+}
+
+// The workflow publishes only after every write succeeds. The pair and README
+// share one report; a failed local write must never be treated as publishable.
+func WriteReadmeWithFieldNotes(path, section string, activity ActivityReport) error {
+	markdown, metadata, err := RenderFieldNotes(activity)
+	if err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	dir, name := filepath.Split(abs)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := checkFieldNotesPath(root, name, false); err != nil {
+		return err
+	}
+	if err := checkFieldNotesPath(root, "reports", true); err != nil {
+		return err
+	}
+	for _, output := range []string{FieldNotesMarkdownPath, FieldNotesJSONPath} {
+		if err := checkFieldNotesPath(root, output, false); err != nil {
+			return err
+		}
+	}
+	current, err := root.ReadFile(name)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Validate the notes markers before replacing the independently owned stats.
+	updated, err := UpdateFieldNotes(current, string(markdown))
+	if err != nil {
+		return err
+	}
+	updated = UpdateReadme(updated, section)
+	if strings.Count(string(updated), FieldNotesStartMarker) != 1 || strings.Count(string(updated), FieldNotesEndMarker) != 1 {
+		return errors.New("field notes markers overlap the activity report")
+	}
+	if err := root.Mkdir("reports", 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	if err := root.WriteFile(FieldNotesMarkdownPath, markdown, 0o600); err != nil {
+		return err
+	}
+	if err := root.WriteFile(FieldNotesJSONPath, metadata, 0o600); err != nil {
+		return err
+	}
+	return root.WriteFile(name, updated, 0o600)
+}
+
+// These two exact paths are reserved outputs, never arbitrary report files.
+func RemoveFieldNotes(repo string) error {
+	root, err := os.OpenRoot(repo)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := checkFieldNotesPath(root, "reports", true); err != nil {
+		return err
+	}
+	for _, name := range []string{FieldNotesMarkdownPath, FieldNotesJSONPath} {
+		if err := checkFieldNotesPath(root, name, false); err != nil {
+			return err
+		}
+	}
+	for _, name := range []string{FieldNotesMarkdownPath, FieldNotesJSONPath} {
+		if err := root.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/report/field_notes.go
+++ b/internal/report/field_notes.go
@@ -11,10 +11,12 @@ import (
 )
 
 const (
-	FieldNotesStartMarker  = "<!-- discrawl-field-notes:start -->"
-	FieldNotesEndMarker    = "<!-- discrawl-field-notes:end -->"
-	FieldNotesMarkdownPath = "reports/latest-field-notes.md"
-	FieldNotesJSONPath     = "reports/latest-field-notes.json"
+	FieldNotesStartMarker       = "<!-- discrawl-aggregate-field-notes:start -->"
+	FieldNotesEndMarker         = "<!-- discrawl-aggregate-field-notes:end -->"
+	LegacyFieldNotesStartMarker = "<!-- discrawl-field-notes:start -->"
+	LegacyFieldNotesEndMarker   = "<!-- discrawl-field-notes:end -->"
+	FieldNotesMarkdownPath      = "reports/latest-field-notes.md"
+	FieldNotesJSONPath          = "reports/latest-field-notes.json"
 )
 
 type FieldNotes struct {

--- a/internal/report/field_notes_test.go
+++ b/internal/report/field_notes_test.go
@@ -167,6 +167,44 @@ func TestFieldNotesReadmeAndArtifacts(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(dir, FieldNotesJSONPath))
 }
 
+func TestFieldNotesPreserveLegacyNarrative(t *testing.T) {
+	legacy := "<!-- discrawl-field-notes:start -->\r\n### Historical narrative fixture\r\n\r\nSynthetic narrative sentinel.  \r\n<!-- discrawl-field-notes:end -->"
+	for _, mode := range []string{"legacy-only", "legacy-with-activity"} {
+		t.Run(mode, func(t *testing.T) {
+			readme := filepath.Join(t.TempDir(), "README.md")
+			base := "# Maintainer instructions\n\n" + legacy + "\n\nManual footer.\n"
+			if mode == "legacy-with-activity" {
+				base = string(UpdateReadme([]byte(base), "old statistics"))
+			}
+			require.NoError(t, os.WriteFile(readme, []byte(base), 0o600))
+			activity := fieldNotesFixture()
+			var previous []byte
+			for range 2 {
+				require.NoError(t, WriteReadmeWithFieldNotes(readme, "new statistics", activity))
+				body, err := os.ReadFile(readme)
+				require.NoError(t, err)
+				require.Contains(t, string(body), legacy)
+				require.Contains(t, string(body), "# Maintainer instructions")
+				require.Contains(t, string(body), "Manual footer.")
+				require.Equal(t, 1, strings.Count(string(body), LegacyFieldNotesStartMarker))
+				require.Equal(t, 1, strings.Count(string(body), FieldNotesStartMarker))
+				if previous != nil {
+					require.True(t, bytes.Equal(previous, body), "repeated rendering must not alter README bytes")
+				}
+				previous = body
+			}
+			activity.TotalMessages++
+			require.NoError(t, WriteReadmeWithFieldNotes(readme, "new statistics", activity))
+			body, err := os.ReadFile(readme)
+			require.NoError(t, err)
+			require.Contains(t, string(body), legacy)
+			require.Contains(t, string(body), "Observed archive: 101 messages")
+			require.NotContains(t, string(body), "Observed archive: 100 messages")
+			require.Equal(t, 1, strings.Count(string(body), FieldNotesStartMarker))
+		})
+	}
+}
+
 func TestFieldNotesRejectMalformedMarkersAndUnsafePaths(t *testing.T) {
 	for _, text := range []string{
 		FieldNotesStartMarker, FieldNotesEndMarker,

--- a/internal/report/field_notes_test.go
+++ b/internal/report/field_notes_test.go
@@ -59,7 +59,7 @@ func TestFieldNotesAggregatePair(t *testing.T) {
 	mdAgain, jsonAgain, err := RenderFieldNotes(activity)
 	require.NoError(t, err)
 	require.Equal(t, markdown, mdAgain)
-	require.Equal(t, metadata, jsonAgain)
+	require.JSONEq(t, string(metadata), string(jsonAgain))
 }
 
 func TestFieldNotesTimestampStates(t *testing.T) {

--- a/internal/report/field_notes_test.go
+++ b/internal/report/field_notes_test.go
@@ -1,0 +1,211 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func fieldNotesFixture() ActivityReport {
+	now := time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC)
+	latest := now.Add(-48 * time.Hour)
+	activity := ActivityReport{
+		GeneratedAt: now, LatestMessageAt: latest,
+		TotalMessages: 100, TotalChannels: 12, TotalMembers: 20,
+		TopChannels: []RankedCount{{Name: "private-channel-sentinel", Count: 10}},
+		TopAuthors:  []RankedCount{{Name: "private-author-sentinel", Count: 10}},
+		BusiestDays: []RankedCount{{Name: "unused-ranking-sentinel", Count: 10}},
+	}
+	for _, hours := range []int{24, 168, 720} {
+		activity.Windows = append(activity.Windows, WindowStats{
+			Label: "unused-label-sentinel", Since: latest.Add(-time.Duration(hours) * time.Hour),
+			Messages: 10, ActiveAuthors: 3, ActiveChannels: 2, Attachments: 4,
+		})
+	}
+	return activity
+}
+
+func TestFieldNotesAggregatePair(t *testing.T) {
+	activity := fieldNotesFixture()
+	markdown, metadata, err := RenderFieldNotes(activity)
+	require.NoError(t, err)
+	var notes FieldNotes
+	require.NoError(t, json.Unmarshal(metadata, &notes))
+	require.Equal(t, 1, notes.Version)
+	require.Equal(t, "deterministic", notes.Generator)
+	require.Equal(t, "published-non-dm", notes.Scope)
+	require.Equal(t, "unknown", notes.Coverage)
+	require.Equal(t, "observed", notes.TimestampStatus)
+	require.Equal(t, int64(172800), *notes.LatestMessageAgeSeconds)
+	require.True(t, notes.WindowAnchorAt.Equal(activity.LatestMessageAt))
+	require.Equal(t, FieldNotesTotals{100, 12, 20}, notes.Totals)
+	require.Len(t, notes.Windows, 3)
+	for i, window := range notes.Windows {
+		require.True(t, window.Since.Equal(activity.Windows[i].Since))
+		require.Equal(t, 4, window.MessagesWithAttachments)
+		require.Contains(t, string(markdown), window.Since.Format(time.RFC3339))
+	}
+	require.Contains(t, string(markdown), "4 messages contain attachments (40.0% of messages)")
+	require.Contains(t, string(markdown), "172800 seconds before generation")
+	require.Contains(t, string(markdown), "not sync freshness")
+	require.NotContains(t, string(markdown)+string(metadata), "sentinel")
+	mdAgain, jsonAgain, err := RenderFieldNotes(activity)
+	require.NoError(t, err)
+	require.Equal(t, markdown, mdAgain)
+	require.Equal(t, metadata, jsonAgain)
+}
+
+func TestFieldNotesTimestampStates(t *testing.T) {
+	for _, state := range []string{"empty", "unavailable", "future"} {
+		t.Run(state, func(t *testing.T) {
+			activity := fieldNotesFixture()
+			switch state {
+			case "empty":
+				activity.TotalMessages = 0
+				activity.LatestMessageAt = time.Time{}
+				activity.Windows = []WindowStats{{Since: activity.GeneratedAt.Add(-24 * time.Hour)}}
+			case "unavailable":
+				activity.LatestMessageAt = time.Time{}
+				activity.Windows[0].Since = activity.GeneratedAt.Add(-24 * time.Hour)
+			case "future":
+				activity.LatestMessageAt = activity.GeneratedAt.Add(24 * time.Hour)
+			}
+			markdown, metadata, err := RenderFieldNotes(activity)
+			require.NoError(t, err)
+			var notes FieldNotes
+			require.NoError(t, json.Unmarshal(metadata, &notes))
+			require.Equal(t, state, notes.TimestampStatus)
+			require.Nil(t, notes.LatestMessageAgeSeconds)
+			require.Equal(t, "unknown", notes.Coverage)
+			require.NotContains(t, string(markdown), "NaN")
+			require.NotContains(t, string(markdown), "Inf")
+			if state != "future" {
+				require.Nil(t, notes.LatestMessageAt)
+				require.True(t, notes.WindowAnchorAt.Equal(activity.GeneratedAt))
+			} else {
+				require.True(t, notes.WindowAnchorAt.Equal(activity.LatestMessageAt))
+				require.Contains(t, string(markdown), "later than report generation")
+			}
+		})
+	}
+}
+
+func TestFieldNotesExistingBuildTimeSemantics(t *testing.T) {
+	for _, timestamp := range []string{"2026-09-08T08:00:00Z", "2099-01-01T00:00:00Z", "not-a-time", ""} {
+		t.Run(timestamp, func(t *testing.T) {
+			s, err := store.Open(t.Context(), filepath.Join(t.TempDir(), "fixture.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = s.Close() })
+			if timestamp != "" {
+				require.NoError(t, s.UpsertMessage(t.Context(), store.MessageRecord{
+					ID: "fixture", GuildID: "guild", ChannelID: "channel", AuthorID: "author",
+					CreatedAt: timestamp, Content: "content-sentinel", RawJSON: `{}`,
+				}))
+			}
+			now := time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC)
+			activity, err := Build(t.Context(), s, Options{Now: now, Published: true})
+			require.NoError(t, err)
+			_, body, err := RenderFieldNotes(activity)
+			require.NoError(t, err)
+			var notes FieldNotes
+			require.NoError(t, json.Unmarshal(body, &notes))
+			anchor := activity.LatestMessageAt
+			if anchor.IsZero() {
+				anchor = now
+			}
+			require.True(t, notes.WindowAnchorAt.Equal(anchor))
+			for i, hours := range []int{24, 168, 720} {
+				require.True(t, notes.Windows[i].Since.Equal(anchor.Add(-time.Duration(hours)*time.Hour)))
+			}
+			require.NotContains(t, string(body), "content-sentinel")
+			if timestamp == "not-a-time" {
+				require.Equal(t, "unavailable", notes.TimestampStatus)
+			}
+		})
+	}
+}
+
+func TestFieldNotesReadmeAndArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	readme := filepath.Join(dir, "README.md")
+	activity := fieldNotesFixture()
+	markdown, metadata, err := RenderFieldNotes(activity)
+	require.NoError(t, err)
+	base := []byte("# Maintainer docs\n\n" + StartMarker + "\nold report\n" + EndMarker + "\n\nmanual notes\n")
+	require.NoError(t, os.WriteFile(readme, base, 0o600))
+	for range 2 {
+		require.NoError(t, WriteReadmeWithFieldNotes(readme, "new statistics", activity))
+		body, err := os.ReadFile(readme)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "# Maintainer docs")
+		require.Contains(t, string(body), "manual notes")
+		require.Contains(t, string(body), strings.TrimSpace(string(markdown)))
+		require.Equal(t, 1, strings.Count(string(body), FieldNotesStartMarker))
+		for name, expected := range map[string][]byte{FieldNotesMarkdownPath: markdown, FieldNotesJSONPath: metadata} {
+			actual, err := os.ReadFile(filepath.Join(dir, name))
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		}
+		updated := UpdateReadme(body, "later scheduled publisher statistics")
+		require.Contains(t, string(updated), strings.TrimSpace(string(markdown)))
+		require.NoError(t, os.WriteFile(readme, updated, 0o600))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "reports", "manual.md"), []byte("keep"), 0o600))
+	require.NoError(t, RemoveFieldNotes(dir))
+	require.NoError(t, RemoveFieldNotes(dir))
+	require.FileExists(t, readme)
+	require.FileExists(t, filepath.Join(dir, "reports", "manual.md"))
+	require.NoFileExists(t, filepath.Join(dir, FieldNotesMarkdownPath))
+	require.NoFileExists(t, filepath.Join(dir, FieldNotesJSONPath))
+}
+
+func TestFieldNotesRejectMalformedMarkersAndUnsafePaths(t *testing.T) {
+	for _, text := range []string{
+		FieldNotesStartMarker, FieldNotesEndMarker,
+		FieldNotesEndMarker + FieldNotesStartMarker,
+		FieldNotesStartMarker + FieldNotesStartMarker + FieldNotesEndMarker,
+		StartMarker + FieldNotesStartMarker + FieldNotesEndMarker + EndMarker,
+	} {
+		t.Run(text, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "README.md")
+			require.NoError(t, os.WriteFile(path, []byte(text), 0o600))
+			require.Error(t, WriteReadmeWithFieldNotes(path, "statistics", fieldNotesFixture()))
+			require.NoDirExists(t, filepath.Join(dir, "reports"))
+			body, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, text, string(body))
+		})
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires Unix permissions")
+	}
+	for _, name := range []string{"reports", FieldNotesMarkdownPath, FieldNotesJSONPath, "README.md"} {
+		t.Run(name, func(t *testing.T) {
+			dir, outside := t.TempDir(), t.TempDir()
+			if name != "reports" {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "reports"), 0o700))
+			}
+			target := filepath.Join(outside, "sentinel")
+			require.NoError(t, os.WriteFile(target, []byte("unchanged"), 0o600))
+			if name == "reports" {
+				target = outside
+			}
+			require.NoError(t, os.Symlink(target, filepath.Join(dir, name)))
+			require.Error(t, WriteReadmeWithFieldNotes(filepath.Join(dir, "README.md"), "stats", fieldNotesFixture()))
+			if name != "README.md" {
+				require.Error(t, RemoveFieldNotes(dir))
+			}
+			body, err := os.ReadFile(filepath.Join(outside, "sentinel"))
+			require.NoError(t, err)
+			require.Equal(t, "unchanged", string(body))
+		})
+	}
+}

--- a/internal/report/field_notes_test.go
+++ b/internal/report/field_notes_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func TestFieldNotesAggregatePair(t *testing.T) {
 	mdAgain, jsonAgain, err := RenderFieldNotes(activity)
 	require.NoError(t, err)
 	require.Equal(t, markdown, mdAgain)
-	require.JSONEq(t, string(metadata), string(jsonAgain))
+	require.True(t, bytes.Equal(metadata, jsonAgain), "field notes JSON bytes must be deterministic")
 }
 
 func TestFieldNotesTimestampStates(t *testing.T) {

--- a/internal/share/publication_files.go
+++ b/internal/share/publication_files.go
@@ -158,7 +158,8 @@ func previousPublicationPaths(ctx context.Context, repo string, includeRemovedRe
 				}
 				hasReport := strings.Contains(string(body), report.StartMarker) && strings.Contains(string(body), report.EndMarker)
 				hasNotes := strings.Contains(string(body), report.FieldNotesStartMarker) && strings.Contains(string(body), report.FieldNotesEndMarker)
-				if hasReport || hasNotes {
+				hasLegacyNotes := strings.Contains(string(body), report.LegacyFieldNotesStartMarker) && strings.Contains(string(body), report.LegacyFieldNotesEndMarker)
+				if hasReport || hasNotes || hasLegacyNotes {
 					files["README.md"] = true
 				}
 			}

--- a/internal/share/publication_files.go
+++ b/internal/share/publication_files.go
@@ -156,7 +156,9 @@ func previousPublicationPaths(ctx context.Context, repo string, includeRemovedRe
 				if err != nil {
 					return nil, err
 				}
-				if strings.Contains(string(body), report.StartMarker) && strings.Contains(string(body), report.EndMarker) {
+				hasReport := strings.Contains(string(body), report.StartMarker) && strings.Contains(string(body), report.EndMarker)
+				hasNotes := strings.Contains(string(body), report.FieldNotesStartMarker) && strings.Contains(string(body), report.FieldNotesEndMarker)
+				if hasReport || hasNotes {
 					files["README.md"] = true
 				}
 			}
@@ -383,6 +385,18 @@ func commitPublication(ctx context.Context, opts Options, message string) (bool,
 			return false, fmt.Errorf("invalid generated README path %q", opts.ReadmePath)
 		}
 		paths[opts.ReadmePath] = true
+	}
+	if opts.Filter.Active() {
+		for _, name := range []string{report.FieldNotesMarkdownPath, report.FieldNotesJSONPath} {
+			_, err := regularFileInRoot(opts.RepoPath, filepath.Join(opts.RepoPath, filepath.FromSlash(name)), name, "publication")
+			if err == nil {
+				return false, errors.New("filtered publication must remove broader-scope field notes before commit")
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return false, err
+			}
+			paths[name] = true
+		}
 	}
 	index, err := publicationGit(ctx, opts.RepoPath, nil, "ls-files", "-z")
 	if err != nil {

--- a/internal/share/publication_files_test.go
+++ b/internal/share/publication_files_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/openclaw/crawlkit/snapshot"
+	"github.com/openclaw/discrawl/internal/report"
 	"github.com/openclaw/discrawl/internal/store"
 	"github.com/stretchr/testify/require"
 )
@@ -230,6 +231,41 @@ func TestPublicationOwnsExactFilesAndPreservesStagedWork(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, committed)
 	require.NotContains(t, testGitOutput(t, ctx, repo, "ls-tree", "-r", "--name-only", "HEAD"), opts.ReadmePath)
+}
+
+func TestFilteredPublicationOwnsOnlyFieldNotesDeletions(t *testing.T) {
+	ctx := t.Context()
+	s := seedStore(t, filepath.Join(t.TempDir(), "fixture.db"))
+	t.Cleanup(func() { _ = s.Close() })
+	repo := t.TempDir()
+	opts := Options{RepoPath: repo, Branch: "main"}
+	_, err := Export(ctx, s, opts)
+	require.NoError(t, err)
+	configureGitUser(t, repo)
+	_, err = Commit(ctx, opts, "test: initial")
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(filepath.Join(repo, "reports"), 0o700))
+	for _, name := range []string{report.FieldNotesMarkdownPath, report.FieldNotesJSONPath, "AGENTS.md", "reports/manual.md"} {
+		require.NoError(t, os.WriteFile(filepath.Join(repo, name), []byte("fixture\n"), 0o600))
+	}
+	testGitRun(t, ctx, repo, "-c", "commit.gpgsign=false", "add", ".")
+	testGitRun(t, ctx, repo, "-c", "commit.gpgsign=false", "commit", "-m", "test: notes and docs")
+	opts.Filter.IncludeChannelIDs = []string{"c1"}
+	_, err = Commit(ctx, opts, "test: must refuse broad notes")
+	require.ErrorContains(t, err, "must remove broader-scope field notes")
+	require.NoError(t, report.RemoveFieldNotes(repo))
+	testGitRun(t, ctx, repo, "add", "-u", "--", report.FieldNotesMarkdownPath)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte("staged maintainer edit\n"), 0o600))
+	testGitRun(t, ctx, repo, "add", "AGENTS.md")
+	changed, err := Commit(ctx, opts, "test: remove only generated notes")
+	require.NoError(t, err)
+	require.True(t, changed)
+	files := strings.Fields(testGitOutput(t, ctx, repo, "ls-tree", "-r", "--name-only", "HEAD"))
+	require.NotContains(t, files, report.FieldNotesMarkdownPath)
+	require.NotContains(t, files, report.FieldNotesJSONPath)
+	require.Contains(t, files, "reports/manual.md")
+	require.Equal(t, "fixture\n", testGitOutput(t, ctx, repo, "show", "HEAD:AGENTS.md"))
+	require.Contains(t, testGitOutput(t, ctx, repo, "diff", "--cached", "--name-only"), "AGENTS.md")
 }
 
 func TestPublicationRejectsUnownedPreviousPaths(t *testing.T) {

--- a/scripts/discord_report_workflow_test.go
+++ b/scripts/discord_report_workflow_test.go
@@ -1,0 +1,109 @@
+//go:build ignore
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+// Explicit-file test, matching the maintenance workflow tests without changing
+// module requirements: go test scripts/discord_report_workflow_test.go
+func TestDiscordReportWorkflow(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "..", ".github", "workflows", "discord-backup-report.yml"))
+	require.NoError(t, err)
+	var workflow struct {
+		On struct {
+			Schedule []struct {
+				Cron string `yaml:"cron"`
+			} `yaml:"schedule"`
+		} `yaml:"on"`
+		Concurrency struct {
+			Group  string `yaml:"group"`
+			Cancel bool   `yaml:"cancel-in-progress"`
+		} `yaml:"concurrency"`
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(body, &workflow))
+	require.Equal(t, "discord-backup-repo", workflow.Concurrency.Group)
+	require.False(t, workflow.Concurrency.Cancel)
+	require.Len(t, workflow.On.Schedule, 1)
+	require.Equal(t, "17 7 * * *", workflow.On.Schedule[0].Cron)
+	require.Len(t, workflow.Jobs, 1)
+	var script string
+	for _, step := range workflow.Jobs["report"].Steps {
+		if step.Name == "Generate daily Discord report" {
+			script = step.Run
+		}
+	}
+	require.NotEmpty(t, script)
+	require.Contains(t, script, `report --published --field-notes --readme "$BACKUP_REPO/README.md"`)
+	require.Equal(t, 1, strings.Count(script, " report --published"))
+	require.Contains(t, script, "report_paths=(README.md reports/latest-field-notes.md reports/latest-field-notes.json)")
+	require.Contains(t, script, `add -- "${report_paths[@]}"`)
+	require.Contains(t, script, `diff --cached --quiet -- "${report_paths[@]}"`)
+	require.Contains(t, script, `commit --only -m "docs: update discord activity report and field notes" -- "${report_paths[@]}"`)
+	require.NotContains(t, script, "add -A")
+	require.NotContains(t, script, "OPENAI")
+	require.NotContains(t, script, "cloud publish")
+
+	start := strings.Index(script, "report_paths=(")
+	end := strings.Index(script, `git -C "$BACKUP_REPO" push`)
+	require.Greater(t, end, start)
+	staging := script[start:end]
+	if runtime.GOOS == "windows" {
+		t.Skip("workflow staging executes Bash on Linux")
+	}
+	dir := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", out)
+		return string(out)
+	}
+	git("init")
+	git("config", "user.name", "Fixture")
+	git("config", "user.email", "fixture@example.invalid")
+	git("config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("unchanged activity\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("committed instructions\n"), 0o600))
+	git("add", ".")
+	git("commit", "-m", "test: original")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("unrelated staged instructions\n"), 0o600))
+	git("add", "AGENTS.md")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "reports"), 0o700))
+	for _, name := range []string{"latest-field-notes.md", "latest-field-notes.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "reports", name), []byte("new untracked artifact\n"), 0o600))
+	}
+	run := func() {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "bash", "-euc", staging)
+		cmd.Env = append(os.Environ(), "BACKUP_REPO="+dir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", out)
+	}
+	before := git("rev-parse", "HEAD")
+	run()
+	require.NotEqual(t, before, git("rev-parse", "HEAD"), "untracked artifacts require a commit")
+	require.Equal(t, "committed instructions\n", git("show", "HEAD:AGENTS.md"))
+	require.Contains(t, git("diff", "--cached", "--name-only"), "AGENTS.md")
+	require.Contains(t, git("ls-tree", "-r", "--name-only", "HEAD"), "reports/latest-field-notes.json")
+	before = git("rev-parse", "HEAD")
+	run()
+	require.Equal(t, before, git("rev-parse", "HEAD"), "unchanged outputs are a no-op")
+}


### PR DESCRIPTION
## Summary

- Add `report --published --field-notes --readme PATH`, deriving deterministic Markdown and JSON notes from the same `ActivityReport` as the existing statistics.
- Write `reports/latest-field-notes.md` and `reports/latest-field-notes.json`, with a separate README marker block. Include only aggregate totals and existing windows, explicit archive-relative timestamps, and unknown coverage.
- Update the daily report workflow to stage exactly the README and artifact pair, including first-time untracked artifacts.
- Remove the reserved broader-scope notes during filtered publication while preserving unrelated documentation and staged changes.
- Document timestamp, privacy, and publication behavior in command docs and the changelog.

No model calls, new SQL/windows, ranked identities, raw message content, dependencies, or shared-library changes. Published reports exclude DMs, not private guild channels. Existing share-filter rejection remains in place.

## Validation

- Focused report, CLI/privacy, and publication-preservation tests passed.
- The same affected behavior passed race tests.
- Standalone parsed workflow tests passed, including first publication, exact staging, unrelated staged-document preservation, and no-op behavior in temporary Git repositories.
- Focused vet, gofmt, gofumpt v0.11.0, actionlint v1.7.12, module tidy/diff, and diff checks passed.
- Fixtures cover empty, unavailable, and future timestamps; anchored windows; attachment-containing message counts; paired artifact/README consistency; DM exclusion; and filtered cleanup.

## Publication Status

No live archive access or report dispatch was used for validation. Initial note population remains pending a successful natural daily report run after merge; adding this capability does not claim notes are already populated.

Normal squash of head `feee4f2de2f8e53a7f5997337ae564b0d37d51ab` is maintainer-authorized, subject to existing required checks.
