### PR TITLE
feat(status): show agents when the last live update was captured

### DIFF
--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -16,6 +16,8 @@ discrawl status
 - channel and thread counts
 - message totals
 - latest archived message time
+- last captured Gateway event time (`last_tail_event_at` in local `--json` output,
+  omitted until a tail event has been recorded), separately from the last completed sync
 - whether the Git share is configured, whether its last check is stale, and whether an exact replacement is pending (`--json`)
 - remote endpoint/archive metadata when `remote.mode = "cloud"`
 - embeddings status if `[search.embeddings]` is enabled

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -65,7 +65,12 @@ func (r *runtime) runMetadata(args []string) error {
 	return r.print(manifest)
 }
 
-func controlStatus(configPath string, cfg config.Config, status store.Status, shareNeedsUpdate bool) control.Status {
+type archiveControlStatus struct {
+	control.Status
+	LastTailEventAt string `json:"last_tail_event_at,omitempty"`
+}
+
+func controlStatus(configPath string, cfg config.Config, status store.Status, shareNeedsUpdate bool) archiveControlStatus {
 	counts := []control.Count{
 		control.NewCount("guilds", "Guilds", int64(status.GuildCount)),
 		control.NewCount("channels", "Channels", int64(status.ChannelCount)),
@@ -93,7 +98,11 @@ func controlStatus(configPath string, cfg config.Config, status store.Status, sh
 		Branch:      cfg.Share.Branch,
 		NeedsUpdate: shareNeedsUpdate,
 	}
-	return out
+	result := archiveControlStatus{Status: out}
+	if !status.LastTailEventAt.IsZero() {
+		result.LastTailEventAt = status.LastTailEventAt.UTC().Format(time.RFC3339)
+	}
+	return result
 }
 
 func fileSize(path string) int64 {

--- a/internal/cli/status_freshness_test.go
+++ b/internal/cli/status_freshness_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusJSONIncludesTailFreshnessWithoutChangingSyncTime(t *testing.T) {
+	cfg, cfgPath := writeTestConfig(t, t.TempDir())
+	s := seedCLIStore(t, cfg.DBPath)
+	defer func() { _ = s.Close() }()
+	_, err := s.DB().ExecContext(t.Context(), `delete from sync_state where scope = 'tail:last_event'`)
+	require.NoError(t, err)
+	require.NoError(t, s.SetSyncState(t.Context(), "sync:last_success", "completed"))
+	_, err = s.DB().ExecContext(t.Context(), `update sync_state set updated_at='2026-09-10T09:00:00Z' where scope='sync:last_success'`)
+	require.NoError(t, err)
+	var before bytes.Buffer
+	require.NoError(t, Run(t.Context(), []string{"--config", cfgPath, "status", "--json"}, &before, &bytes.Buffer{}))
+	var withoutTail map[string]any
+	require.NoError(t, json.Unmarshal(before.Bytes(), &withoutTail))
+	require.NotContains(t, withoutTail, "last_tail_event_at")
+
+	require.NoError(t, s.SetSyncState(t.Context(), "tail:last_event", "message-id"))
+	_, err = s.DB().ExecContext(t.Context(), `update sync_state set updated_at='2026-09-10T10:00:00Z' where scope='tail:last_event'`)
+	require.NoError(t, err)
+	var after bytes.Buffer
+	require.NoError(t, Run(t.Context(), []string{"--config", cfgPath, "status", "--json"}, &after, &bytes.Buffer{}))
+	var withTail map[string]any
+	require.NoError(t, json.Unmarshal(after.Bytes(), &withTail))
+	require.Equal(t, "2026-09-10T10:00:00Z", withTail["last_tail_event_at"])
+	require.Equal(t, "2026-09-10T09:00:00Z", withTail["last_sync_at"])
+	require.Equal(t, withoutTail["schema_version"], withTail["schema_version"])
+	require.Equal(t, withoutTail["counts"], withTail["counts"])
+}


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

An agent pulling data from the archive cannot tell from `discrawl status --json` when the latest live Discord update was captured. The last completed sync may be hours old even while live ingestion is active, forcing the agent to run a separate SQL or diagnostics step before it has the freshness context needed to interpret the data.

## Why This Change Was Made

Include the existing last-tail-event timestamp as optional `last_tail_event_at` in local status JSON, alongside the completed-sync timestamp. The value is already collected for status, so exposing it adds no database query, migration, or authentication request.

## User Impact

Agents get live-ingestion freshness context in the same status response they already read, avoiding a separate freshness-query step. The field is a UTC timestamp and is omitted until a tail event has been recorded. Existing fields retain their meanings, and human-readable and cloud status output follow their existing paths.

The timestamp describes the latest recorded tail event; it does not establish complete coverage for every channel.

## Evidence

For a repair completed at 09:00 followed by a captured live event at 10:00, status JSON now provides both signals:

```json
{
  "last_sync_at": "2026-09-10T09:00:00Z",
  "last_tail_event_at": "2026-09-10T10:00:00Z"
}
```

The regression test exercises the CLI against a real fixture database. It verifies omission before the first event, inclusion afterward, and preservation of sync time, counts, and the schema identifier.

- `go test -count=1 -skip '^TestPublishProducerValidationBeforeMutation$' ./internal/cli` passed.
- `go vet ./internal/cli` passed.
- The excluded test was rerun and still hits the existing unrelated publication-fixture failure: `tracked remote branch origin/main is missing`. Publication/report code is unchanged by this PR.
