### PR TITLE
docs: guide pull requests with problem-first descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+below this comment.
+
+Required PR title:
+type: user-facing description
+Use a parenthesized scope only when it adds clarity:
+fix(auth): login redirect loops when session cookie is expired
+
+Types: feat, fix, improve, refactor, docs, chore.
+For fixes, describe the user-visible symptom and trigger:
+fix: task list fails to load when user has no environments
+Avoid implementation details such as:
+fix: add null check to task query
+-->
+
+<details>
+<summary>Additional instructions</summary>
+
+**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
+can help update the branch when needed.
+
+</details>
+
+## What Problem This Solves
+
+<!--
+Describe the concrete user, product, or operational problem.
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+or:
+"Resolves a problem where..."
+
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
+
+## Why This Change Was Made
+
+<!--
+In one or two sentences, explain the complete shipped solution, key design
+decisions, and relevant boundaries or non-goals. Include implementation detail
+only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
+
+## User Impact
+
+<!--
+State what users, operators, or developers can now do or expect. Lead with the
+concrete benefit and use user-facing language. If there is no user-visible
+impact, say so plainly.
+-->
+
+## Evidence
+
+<!--
+Show the most useful proof that this change works. Screenshots, screencasts,
+terminal output, focused tests, CI results, live observations, redacted logs,
+and artifact links are all useful. Include before/after evidence for visual
+changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make the
+validation easy to understand, not to restate the diff.
+-->


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #125

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Discrawl contributors and reviewing agents need PR descriptions that explain the concrete problem before the implementation. Without a consistent starting structure, descriptions can lead with code changes and leave reviewers to reconstruct why the change matters, who benefits, and what evidence supports it.

## Why This Change Was Made

Add OpenClaw's current default pull-request template unchanged at GitHub's standard `.github/pull_request_template.md` location. It provides the four problem-first sections, optional linked-context guidance, user-facing title guidance, and the reminder to keep maintainer edits enabled.

The identical template was previously proposed in #125, which was closed without merging. Discrawl still has no default PR template; this proposal adds the current canonical template.

## User Impact

Contributors opening new PRs through GitHub receive a problem-first description structure. Agents and command-line contributors can use the same repository template, and reviewers get consistent sections for the problem, rationale, impact, and evidence.

This is contributor-workflow guidance; there is no change to Discrawl's CLI, archive data, or runtime behavior.

## Evidence

- Copied byte-for-byte from [OpenClaw's template at commit `4ae4b5c`](https://github.com/openclaw/openclaw/blob/4ae4b5c2a464608045e29fe72793dbb6fbbcdad7/.github/pull_request_template.md).
- Both files have Git blob ID `e902c4789b21765ea16dfb75e436db5801b6450b`.
- `git diff --check` passed.
- The diff adds one Markdown file at GitHub's supported default-template path. Runtime tests are not applicable to this documentation-only change.
