### PR TITLE
docs: document status freshness and index upgrade costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Include the last captured Gateway event time as optional `last_tail_event_at` in local `status --json`, separately from the last completed sync.
+- Speed per-channel changed-message queries with an additive update-cursor index; document synchronous first-writable-open cost and backup-first, measured canary prerequisites before broader rollout.
 - Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, separate markers preserving legacy narrative notes, explicit timestamp and coverage limits, and filtered-publication cleanup.
 
 ## 0.14.1 - 2026-09-09

--- a/docs/guides/data-storage.md
+++ b/docs/guides/data-storage.md
@@ -45,6 +45,39 @@ The schema is multi-guild ready even when the common UX stays single-guild simpl
 
 SQLite schema migrations are versioned with `PRAGMA user_version`. Startup fails fast when a local DB schema is newer than the supported binary - that means you have a binary older than the database.
 
+Index maintenance also runs on writable opens of an already-versioned database.
+An unchanged `user_version` therefore does not mean that a writer open will do
+no schema work. Read-only opens do not run this maintenance.
+
+### Channel update-cursor index
+
+After v0.14.1, Discrawl adds `idx_messages_channel_updated_id` on
+`messages(channel_id, updated_at, id)` for per-channel changed-message queries.
+It preserves the existing creation-time indexes and does not change
+`user_version`. The first writable open that finds the index missing builds it
+synchronously before returning; later opens retain the existing index.
+
+That first build can delay the initiating command and other writers. Build
+duration, peak memory, temporary disk requirements, persistent index size and
+ongoing message-write overhead remain **unmeasured for the target archive**.
+Small synthetic read timings and successful CI are not production capacity
+estimates or acceptance of those costs. The historical operational decision in
+[PR214](https://github.com/openclaw/discrawl/pull/214) is not resolved by this
+documentation.
+
+### Before broader index rollout
+
+Require an explicitly approved, backup-first canary and a decision on its
+measurements before expanding adoption. These are operator prerequisites, not
+an automatic software gate or authorization to run a canary:
+
+1. Have the owner approve the candidate revision, isolated target, maintenance coordination and rollback plan. Define elapsed-time, peak-memory, disk headroom and write-impact limits, with stop criteria, before starting.
+2. Coordinate archive writers and take a verified SQLite-consistent backup under that plan. Retain the matching pre-upgrade binary and configuration. Do not copy only the main database file while uncheckpointed WAL data may exist; use an approved consistent-backup method and verify restoration.
+3. Use a separately approved disposable copy, with explicit isolated config, database, cache, log and share paths. Prevent provider, Git-share and backend requests. Do not run collection or publication, and leave the source archive and other deployments untouched.
+4. On that copy only, measure the first writable open, peak memory, temporary and persistent disk growth, remaining headroom, and a bounded local write workload before and after the index. Keep archive contents private; record aggregate measurements and the exact candidate revision.
+5. Stop expansion if a limit is exceeded or evidence is incomplete. The owner must explicitly approve the measured tradeoff for the intended rollout; successful publication elsewhere does not establish acceptable local costs.
+6. For rollback, restore the matching pre-upgrade binary, configuration and database from the verified backup, accounting for any writes since backup. A binary downgrade alone is not a verified rollback plan.
+
 ## Failure history
 
 `failure_ledger` records bounded error text and available Discord row


### PR DESCRIPTION
Related: https://github.com/openclaw/discrawl/pull/212
Related: https://github.com/openclaw/discrawl/pull/214

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a documentation gap where operators checking unreleased changes could
miss the new local status timestamp and the first-writable-open cost of the
channel update-cursor index.

## Why This Change Was Made

Adds the missing changelog entries and extends the existing storage guide with
backup-first, measured canary prerequisites before broader index adoption.
The site's changelog is an existing symlink to the root changelog, so two
tracked-file edits cover all three documentation surfaces without replacing
that alias. Application code, workflows and dependencies are unchanged.

## User Impact

Operators can distinguish the last captured Gateway event from a completed
sync and plan an isolated index-upgrade evaluation with explicit limits,
backup verification, measurement and rollback prerequisites.

Target-archive build time, memory, disk and write costs remain unmeasured.
This PR does not retrospectively accept those costs or clear PR214's historical
operational decision. A separate operator decision on measurements is still
required before broader adoption. No canary, data operation or rollout is
authorized or performed by this documentation change.

## Evidence

- `node scripts/build-docs-site.mjs` passed.
- `git diff --check` passed; the diff contains only the two intended Markdown
  files. The changelog symlink and application/workflow/dependency files remain
  unchanged.
- Rendered checks passed for both new guide anchors, all six complete ordered
  list items, the public PR link and the mirrored site changelog entries.
- Structured docs review completed with no findings.
- Separate read-only metadata observation:
  [September 11 scheduled daily report](https://github.com/openclaw/discrawl/actions/runs/34574541889)
  succeeded. That is not index-performance evidence or a claim about generated
  content equality, freshness or completeness.

This is a documentation-only follow-up. No runtime test suite, production
benchmark, workflow dispatch, release or live-data operation was run for it.
