### PR TITLE
feat: keep embeddings current while Discord capture continues

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ discrawl sync
 
 `sync` collects recent data by default. Run `discrawl sync --full` when you want a historical backfill; large guilds can take time because Discord rate-limits history requests. [`tail`](docs/commands/tail.md) keeps an archive current from Gateway events and periodic repair passes.
 
+With embeddings configured, `discrawl tail --embed-live` keeps embeddings current in background workers while capture continues. See [continuous embeddings](docs/guides/embeddings.md#continuous-embedding-during-capture).
+
 ## Search and inspect
 
 FTS5 search works without external services:

--- a/docs/commands/embed.md
+++ b/docs/commands/embed.md
@@ -35,6 +35,10 @@ After changing `[search.embeddings]` provider, model, or any input setting, when
 
 `sync --with-embeddings` enqueues; `embed` drains. The two phases are intentionally separate so a slow provider does not block the hot sync path.
 
+For continuous capture with background embedding, use `discrawl tail --embed-live`.
+Do not run a separate drain against the tail owner; live mode coordinates both
+inside one process.
+
 ## See also
 
 - [Embeddings guide](../guides/embeddings.html)

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -29,3 +29,5 @@ discrawl status
 - [`doctor`](doctor.html) - liveness check (config, auth, DB, FTS wiring)
 - [`remote`](remote.html) - direct Cloudflare remote archive checks
 - [`report`](report.html) - Markdown activity block for the shared backup README
+
+When continuous embeddings have been used, `background_work` reports worker lifecycle, pending and in-flight work, queue age, last completion, and safe error codes. A missing heartbeat is reported as stale, rather than claiming a stopped worker is healthy.

--- a/docs/commands/tail.md
+++ b/docs/commands/tail.md
@@ -8,6 +8,7 @@ Runs the live Discord Gateway tail and a periodic repair loop.
 discrawl tail
 discrawl --verbose tail
 discrawl tail --with-embeddings
+discrawl tail --embed-live
 discrawl tail --guild 123456789012345678
 discrawl tail --repair-every 30m
 discrawl tail --replay-failures-only
@@ -27,6 +28,7 @@ discrawl tail --replay-failures-only
 
 - `--guild <id>` / `--guilds <id,id>` - tail a specific guild scope (default: `default_guild_id`, or all discovered guilds if unset)
 - `--repair-every <duration>` - frequency of the repair sweep
+- `--embed-live` - continuously process queued embeddings while capture continues (opt-in; implies queueing; requires configured embeddings)
 - `--with-embeddings` - queue live, replayed, and repair messages for embedding (default: off)
 - `--replay-failures-only` - replay unresolved exact-message tail failures and exit
 - `--replay-limit <n>` - maximum failures to inspect in replay-only mode (default and maximum: `25`)

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -77,8 +77,9 @@ also queues new messages, edits, replay and repair work. Embeddings must already
 be enabled in the configuration. Ordinary `tail --with-embeddings` still only
 queues work; `embed` remains the bounded one-shot drain.
 
-Two workers process batches of at most 64 inputs, with a 250 ms batching window
-and one-second fallback polling. Fresh Gateway content takes priority over sync
+Two workers honor the configured batch size up to a maximum of 64 inputs, with a 250 ms batching window
+and one-second fallback polling. The worker deadline includes the configured
+provider request timeout plus 30 seconds for preparation and result handling. Fresh Gateway content takes priority over sync
 catch-up, with capacity reserved for catch-up. Healthy-provider freshness targets
 are measured from the source transaction to the committed vector; ten seconds
 is a target under normal load, not a promise during provider outages or overload.

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -69,3 +69,41 @@ The snapshot stores vectors under `embeddings/<provider>/<model>/<input_version>
 - [Search modes](search-modes.html)
 - [`embed`](../commands/embed.html)
 - [Configuration](../configuration.html)
+
+## Continuous embedding during capture
+
+`discrawl tail --embed-live` opts into crawlkit's background worker runtime and
+also queues new messages, edits, replay and repair work. Embeddings must already
+be enabled in the configuration. Ordinary `tail --with-embeddings` still only
+queues work; `embed` remains the bounded one-shot drain.
+
+Two workers process batches of at most 64 inputs, with a 250 ms batching window
+and one-second fallback polling. Fresh Gateway content takes priority over sync
+catch-up, with capacity reserved for catch-up. Healthy-provider freshness targets
+are measured from the source transaction to the committed vector; ten seconds
+is a target under normal load, not a promise during provider outages or overload.
+
+The tail process retains its normal exclusive writer ownership. Background
+workers share it in-process, make provider calls outside database transactions,
+and prepare content on a separate read connection. Do not schedule another
+`embed` command against a running tail. No stop/embed/restart cycle is needed in
+live mode.
+
+Queue revisions and expiring random claim tokens fence results, retries and
+release. Edits invalidate queued claims and stale vectors; deletes cannot be
+resurrected by a late provider response. Completion also checks the current source
+text and eligibility. Interrupted work is recovered by the next exclusive tail
+owner. Model/provider changes continue to use the existing rebuild contract.
+
+Provider outages, missing credentials and throttling leave capture running.
+Transient provider failures pause processing and retry; rate-limit Retry-After
+values are respected. Invalid input/results remain visible as failed jobs.
+`status --json` adds `background_work`, including lifecycle, pending/in-flight
+counts, oldest pending input, last success and safe error codes. Worker status
+is local-only and is never included in published snapshots.
+
+This feature upgrades the local schema from 5 to 6 without regenerating existing
+vectors. Back up before upgrading. To roll back the feature, keep the
+schema-compatible binary, omit `--embed-live`, and return to serialized one-shot
+embedding. Older binaries cannot open schema 6; do not overwrite newly captured
+data with a pre-upgrade database merely to disable the worker.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/openclaw/crawlkit v0.15.0
+	github.com/openclaw/crawlkit v0.16.0
 	github.com/stretchr/testify v1.12.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
-github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
+github.com/openclaw/crawlkit v0.16.0 h1:zLjLAWqJR9KM2U50nQ+yCAxiCJ/tnayDgPs4UanEi+I=
+github.com/openclaw/crawlkit v0.16.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -331,6 +331,7 @@ func (r *runtime) runTail(args []string) error {
 	fs.SetOutput(io.Discard)
 	repairEvery := fs.Duration("repair-every", mustDuration(r.cfg.Sync.RepairEvery), "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
+	embedLive := fs.Bool("embed-live", false, "")
 	replayFailuresOnly := fs.Bool("replay-failures-only", false, "")
 	replayLimit := fs.Int("replay-limit", syncer.TailMessageReplayLimit, "")
 	guildsFlag := fs.String("guilds", "", "")
@@ -354,8 +355,14 @@ func (r *runtime) runTail(args []string) error {
 			syncer.TailMessageReplayLimit,
 		))
 	}
+	if *embedLive && *replayFailuresOnly {
+		return usageErr(errors.New("--embed-live cannot be combined with --replay-failures-only"))
+	}
+	if *embedLive && !r.cfg.Search.Embeddings.Enabled {
+		return usageErr(errors.New("--embed-live requires embeddings enabled in config"))
+	}
 	if configurable, ok := r.syncer.(tailEmbeddingsConfigurer); ok {
-		configurable.SetTailEmbeddings(*withEmbeddings)
+		configurable.SetTailEmbeddings(*withEmbeddings || *embedLive)
 	}
 	guildIDs := r.resolveSyncGuilds(*guildFlag, *guildsFlag)
 	if *replayFailuresOnly {
@@ -377,6 +384,9 @@ func (r *runtime) runTail(args []string) error {
 			return r.activateTailSyncLock()
 		})
 		defer configurable.SetTailReadyCallback(nil)
+	}
+	if *embedLive {
+		return r.runTailWithEmbeddingWorker(ctx, guildIDs, *repairEvery)
 	}
 	return r.syncer.RunTail(ctx, guildIDs, *repairEvery)
 }

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -66,6 +66,7 @@ func (r *runtime) runMetadata(args []string) error {
 }
 
 type archiveControlStatus struct {
+	BackgroundWork *store.EmbeddingWorkerStatus `json:"background_work,omitempty"`
 	control.Status
 	LastTailEventAt string `json:"last_tail_event_at,omitempty"`
 }
@@ -98,7 +99,7 @@ func controlStatus(configPath string, cfg config.Config, status store.Status, sh
 		Branch:      cfg.Share.Branch,
 		NeedsUpdate: shareNeedsUpdate,
 	}
-	result := archiveControlStatus{Status: out}
+	result := archiveControlStatus{Status: out, BackgroundWork: status.BackgroundWork}
 	if !status.LastTailEventAt.IsZero() {
 		result.LastTailEventAt = status.LastTailEventAt.UTC().Format(time.RFC3339)
 	}

--- a/internal/cli/embedding_worker.go
+++ b/internal/cli/embedding_worker.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/openclaw/crawlkit/embed"
+	"github.com/openclaw/crawlkit/worker"
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+// Configuration/credential failures disable processing, never raw capture.
+// Retrying construction allows temporarily unavailable credentials to recover.
+type deferredEmbeddingProvider struct {
+	mu       sync.Mutex
+	provider embed.Provider
+	create   func() (embed.Provider, error)
+}
+
+func (p *deferredEmbeddingProvider) Embed(ctx context.Context, inputs []string) (embed.EmbeddingBatch, error) {
+	p.mu.Lock()
+	if p.provider == nil {
+		v, err := p.create()
+		if err != nil || v == nil {
+			p.mu.Unlock()
+			return embed.EmbeddingBatch{}, &worker.Failure{Code: "embedding_provider_configuration", Pause: true, RetryAfter: time.Minute}
+		}
+		p.provider = v
+	}
+	provider := p.provider
+	p.mu.Unlock()
+	return provider.Embed(ctx, inputs)
+}
+
+func (r *runtime) runTailWithEmbeddingWorker(ctx context.Context, guilds []string, repair time.Duration) error {
+	create := r.newEmbed
+	if create == nil {
+		create = func(c config.EmbeddingsConfig) (embed.Provider, error) {
+			return embed.NewProvider(crawlkitEmbeddingConfig(c))
+		}
+	}
+	provider := &deferredEmbeddingProvider{create: func() (embed.Provider, error) { return create(r.cfg.Search.Embeddings) }}
+	w, err := r.store.NewEmbeddingWorker(ctx, provider, store.EmbeddingDrainOptions{Provider: r.cfg.Search.Embeddings.Provider, Model: r.cfg.Search.Embeddings.Model, InputVersion: store.EmbeddingInputVersion, MaxInputChars: r.cfg.Search.Embeddings.MaxInputChars})
+	if err != nil {
+		return err
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- w.Run(workerCtx) }()
+	tailErr := r.syncer.RunTail(ctx, guilds, repair)
+	cancel()
+	return errors.Join(tailErr, <-done)
+}

--- a/internal/cli/embedding_worker.go
+++ b/internal/cli/embedding_worker.go
@@ -43,7 +43,7 @@ func (r *runtime) runTailWithEmbeddingWorker(ctx context.Context, guilds []strin
 		}
 	}
 	provider := &deferredEmbeddingProvider{create: func() (embed.Provider, error) { return create(r.cfg.Search.Embeddings) }}
-	w, err := r.store.NewEmbeddingWorker(ctx, provider, store.EmbeddingDrainOptions{Provider: r.cfg.Search.Embeddings.Provider, Model: r.cfg.Search.Embeddings.Model, InputVersion: store.EmbeddingInputVersion, MaxInputChars: r.cfg.Search.Embeddings.MaxInputChars})
+	w, err := r.store.NewEmbeddingWorker(ctx, provider, store.EmbeddingDrainOptions{Provider: r.cfg.Search.Embeddings.Provider, Model: r.cfg.Search.Embeddings.Model, InputVersion: store.EmbeddingInputVersion, MaxInputChars: r.cfg.Search.Embeddings.MaxInputChars, BatchSize: r.cfg.Search.Embeddings.BatchSize, RequestTimeout: mustDuration(r.cfg.Search.Embeddings.RequestTimeout)})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/embedding_worker_test.go
+++ b/internal/cli/embedding_worker_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crawlkit/embed"
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/openclaw/discrawl/internal/syncer"
+	"github.com/stretchr/testify/require"
+)
+
+type liveCLISync struct {
+	*fakeSyncService
+	live func(context.Context) error
+}
+
+func (s *liveCLISync) RunTail(ctx context.Context, g []string, d time.Duration) error {
+	if err := s.fakeSyncService.RunTail(ctx, g, d); err != nil {
+		return err
+	}
+	return s.live(ctx)
+}
+
+type liveCLIProvider func(context.Context, []string) (embed.EmbeddingBatch, error)
+
+func (f liveCLIProvider) Embed(ctx context.Context, v []string) (embed.EmbeddingBatch, error) {
+	return f(ctx, v)
+}
+
+func TestTailLiveEmbeddingsKeepsCaptureAndWriterOwnership(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "archive.db")
+	cfg.CacheDir = filepath.Join(dir, "cache")
+	cfg.LogDir = filepath.Join(dir, "logs")
+	cfg.Share.RepoPath = filepath.Join(dir, "share")
+	cfg.Share.AutoUpdate = false
+	cfg.Search.Embeddings.Enabled = true
+	cfg.Search.Embeddings.Provider = "openai"
+	cfg.Search.Embeddings.Model = "fixture"
+	p := filepath.Join(dir, "config.toml")
+	require.NoError(t, config.Write(p, cfg))
+	fake := &fakeSyncService{callTailReady: true}
+	rt := tailTestRuntime(ctx, p, fake)
+	var requests atomic.Int32
+	rt.newEmbed = func(config.EmbeddingsConfig) (embed.Provider, error) {
+		return liveCLIProvider(func(ctx context.Context, texts []string) (embed.EmbeddingBatch, error) {
+			requests.Add(1)
+			select {
+			case <-time.After(200 * time.Millisecond):
+			case <-ctx.Done():
+				return embed.EmbeddingBatch{}, ctx.Err()
+			}
+			v := make([][]float32, len(texts))
+			for i := range v {
+				v[i] = []float32{1, 2}
+			}
+			return embed.EmbeddingBatch{Vectors: v}, nil
+		}), nil
+	}
+	rt.newSyncer = func(_ syncer.Client, s *store.Store, _ *slog.Logger) syncService {
+		return &liveCLISync{fakeSyncService: fake, live: func(ctx context.Context) error {
+			require.True(t, fake.tailEmbeddings)
+			lockPath, e := rt.syncLockPath()
+			require.NoError(t, e)
+			owner, ok := readSyncLockOwner(lockPath)
+			require.True(t, ok)
+			require.Equal(t, "tail", owner.Operation)
+			for i := range 10 {
+				start := time.Now()
+				require.NoError(t, s.UpsertMessageWithOptions(ctx, store.MessageRecord{ID: strconv.Itoa(100 + i), GuildID: "g", ChannelID: "c", Content: "live", NormalizedContent: "live"}, store.WriteOptions{EnqueueEmbedding: true}))
+				require.Less(t, time.Since(start), time.Second)
+				time.Sleep(100 * time.Millisecond)
+			}
+			require.Eventually(t, func() bool {
+				var n int
+				_ = s.DB().QueryRowContext(t.Context(), `select count(*) from message_embeddings`).Scan(&n)
+				return n == 10
+			}, 5*time.Second, 20*time.Millisecond)
+			require.True(t, rt.dbLockHeld)
+			return nil
+		}}
+	}
+	require.NoError(t, rt.dispatch([]string{"tail", "--embed-live", "--guild", "g"}))
+	require.Positive(t, requests.Load())
+	require.Equal(t, 1, fake.tailCalls)
+}
+
+func TestTailLiveFlagValidation(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		cfg := config.Default()
+		root := t.TempDir()
+		cfg.DBPath = filepath.Join(root, "db")
+		cfg.CacheDir = filepath.Join(root, "cache")
+		cfg.LogDir = filepath.Join(root, "logs")
+		cfg.Share.RepoPath = filepath.Join(root, "share")
+		cfg.Search.Embeddings.Enabled = enabled
+		cfg.Share.AutoUpdate = false
+		p := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, config.Write(p, cfg))
+		f := &fakeSyncService{}
+		rt := tailTestRuntime(t.Context(), p, f)
+		args := []string{"tail", "--embed-live"}
+		if enabled {
+			args = append(args, "--replay-failures-only")
+		}
+		require.Error(t, rt.dispatch(args))
+		require.Zero(t, f.tailCalls)
+	}
+}
+
+func TestDeferredEmbeddingProviderConfigurationFailure(t *testing.T) {
+	var count int
+	p := &deferredEmbeddingProvider{create: func() (embed.Provider, error) {
+		count++
+		if count == 1 {
+			return nil, errors.New("secret credential")
+		}
+		return liveCLIProvider(func(context.Context, []string) (embed.EmbeddingBatch, error) {
+			return embed.EmbeddingBatch{Vectors: [][]float32{{1}}}, nil
+		}), nil
+	}}
+	_, err := p.Embed(t.Context(), []string{"a"})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "secret")
+	_, err = p.Embed(t.Context(), []string{"a"})
+	require.NoError(t, err)
+	_, err = p.Embed(t.Context(), []string{"a"})
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestTailLiveMissingCredentialsDoesNotStopCapture(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 8*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "archive.db")
+	cfg.CacheDir = filepath.Join(dir, "cache")
+	cfg.LogDir = filepath.Join(dir, "logs")
+	cfg.Share.RepoPath = filepath.Join(dir, "share")
+	cfg.Share.AutoUpdate = false
+	cfg.Search.Embeddings.Enabled = true
+	p := filepath.Join(dir, "config.toml")
+	require.NoError(t, config.Write(p, cfg))
+	fake := &fakeSyncService{}
+	rt := tailTestRuntime(ctx, p, fake)
+	rt.newEmbed = func(config.EmbeddingsConfig) (embed.Provider, error) { return nil, errors.New("missing secret") }
+	rt.newSyncer = func(_ syncer.Client, s *store.Store, _ *slog.Logger) syncService {
+		return &liveCLISync{fakeSyncService: fake, live: func(ctx context.Context) error {
+			require.NoError(t, s.UpsertMessageWithOptions(ctx, store.MessageRecord{ID: "100", GuildID: "g", ChannelID: "c", Content: "first", NormalizedContent: "first"}, store.WriteOptions{EnqueueEmbedding: true}))
+			require.Eventually(t, func() bool {
+				status, e := s.ReadEmbeddingWorkerStatus(ctx)
+				return e == nil && status != nil && status.State == "paused"
+			}, 4*time.Second, 20*time.Millisecond)
+			require.NoError(t, s.UpsertMessageWithOptions(ctx, store.MessageRecord{ID: "101", GuildID: "g", ChannelID: "c", Content: "second", NormalizedContent: "second"}, store.WriteOptions{EnqueueEmbedding: true}))
+			var n int
+			require.NoError(t, s.DB().QueryRowContext(t.Context(), `select count(*) from messages`).Scan(&n))
+			require.Equal(t, 2, n)
+			return nil
+		}}
+	}
+	require.NoError(t, rt.dispatch([]string{"tail", "--embed-live"}))
+}

--- a/internal/cli/embedding_worker_test.go
+++ b/internal/cli/embedding_worker_test.go
@@ -48,6 +48,8 @@ func TestTailLiveEmbeddingsKeepsCaptureAndWriterOwnership(t *testing.T) {
 	cfg.Search.Embeddings.Enabled = true
 	cfg.Search.Embeddings.Provider = "openai"
 	cfg.Search.Embeddings.Model = "fixture"
+	cfg.Search.Embeddings.BatchSize = 2
+	cfg.Search.Embeddings.RequestTimeout = "5m"
 	p := filepath.Join(dir, "config.toml")
 	require.NoError(t, config.Write(p, cfg))
 	fake := &fakeSyncService{callTailReady: true}
@@ -55,6 +57,9 @@ func TestTailLiveEmbeddingsKeepsCaptureAndWriterOwnership(t *testing.T) {
 	var requests atomic.Int32
 	rt.newEmbed = func(config.EmbeddingsConfig) (embed.Provider, error) {
 		return liveCLIProvider(func(ctx context.Context, texts []string) (embed.EmbeddingBatch, error) {
+			if len(texts) > 2 {
+				return embed.EmbeddingBatch{}, errors.New("configured batch limit exceeded")
+			}
 			requests.Add(1)
 			select {
 			case <-time.After(200 * time.Millisecond):

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -130,10 +130,11 @@ Sync Discord or desktop-cache data into the local archive.
 Configure Discord collection scope with sync.include_category_ids,
 sync.exclude_channel_ids, and sync.exclude_channel_kinds; exclusions win.
 `,
-	"tail": `Usage: discrawl tail [--repair-every DURATION] [--with-embeddings] [--guild ID|--guilds IDS] [--replay-failures-only [--replay-limit N]]
+	"tail": `Usage: discrawl tail [--repair-every DURATION] [--with-embeddings] [--embed-live] [--guild ID|--guilds IDS] [--replay-failures-only [--replay-limit N]]
 
 Continuously archive new Discord messages.
 Use --with-embeddings to queue live, replayed, and repair messages for embedding.
+Use --embed-live to also process embeddings continuously without pausing capture.
 The sync.include_category_ids, sync.exclude_channel_ids, and
 sync.exclude_channel_kinds settings apply to live events and repair syncs.
 `,

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -2124,7 +2124,7 @@ func (f *snapshotFilter) allowSyncState(scope string) bool {
 		channelID, _, _ := strings.Cut(rest, ":")
 		return f.allowChannelID(channelID)
 	}
-	if strings.HasPrefix(scope, "wiretap:") {
+	if strings.HasPrefix(scope, "wiretap:") || strings.HasPrefix(scope, "worker:") {
 		return false
 	}
 	if strings.HasPrefix(scope, "share:") {
@@ -2342,7 +2342,7 @@ func snapshotExportQuery(table string) (string, []any) {
 	case "channels", "members", "messages", "message_events", "message_attachments", "mention_events":
 		return "select * from " + table + " where guild_id != ?", []any{directMessageGuildID}
 	case "sync_state":
-		return "select * from sync_state where scope not like 'wiretap:%'", nil
+		return "select * from sync_state where scope not like 'wiretap:%' and scope not like 'worker:%'", nil
 	default:
 		return "select * from " + table, nil
 	}
@@ -2357,7 +2357,7 @@ func snapshotDeleteQuery(table string) (string, []any) {
 	case "channels", "members", "messages", "message_attachments":
 		return "delete from " + table + " where guild_id != ?", []any{directMessageGuildID}
 	case "sync_state":
-		return "delete from sync_state where scope not like 'wiretap:%'", nil
+		return "delete from sync_state where scope not like 'wiretap:%' and scope not like 'worker:%'", nil
 	default:
 		return "delete from " + table, nil
 	}
@@ -2371,7 +2371,7 @@ func isDirectMessageSnapshotRow(table string, row map[string]any) bool {
 		return isLocalOnlyGuildID(stringValue(row["guild_id"]))
 	case "sync_state":
 		scope := stringValue(row["scope"])
-		return strings.HasPrefix(scope, "wiretap:")
+		return (strings.HasPrefix(scope, "wiretap:") || strings.HasPrefix(scope, "worker:"))
 	default:
 		return false
 	}

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1281,6 +1281,7 @@ func TestSnapshotExcludesAndPreservesDirectMessages(t *testing.T) {
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
 	seedDirectMessageData(t, ctx, src)
+	require.NoError(t, src.SetSyncState(ctx, "worker:embeddings", "private worker status"))
 
 	repo := filepath.Join(t.TempDir(), "share")
 	manifest, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
@@ -1292,6 +1293,7 @@ func TestSnapshotExcludesAndPreservesDirectMessages(t *testing.T) {
 	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, manifest, "channels")), directMessageGuildID)
 	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, manifest, "messages")), "private dm content")
 	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, manifest, "sync_state")), "wiretap:last_import")
+	require.NotContains(t, snapshotTableText(t, repo, tableEntry(t, manifest, "sync_state")), "worker:embeddings")
 	manifest = appendSnapshotRow(t, repo, manifest, "messages", map[string]any{
 		"id":                 "hostile-dm",
 		"guild_id":           directMessageGuildID,
@@ -2158,7 +2160,7 @@ func TestShareSmallHelpersAndValidation(t *testing.T) {
 	require.Equal(t, "select * from guilds where id != ?", query)
 	require.Equal(t, []any{directMessageGuildID}, args)
 	query, args = snapshotExportQuery("sync_state")
-	require.Equal(t, "select * from sync_state where scope not like 'wiretap:%'", query)
+	require.Equal(t, "select * from sync_state where scope not like 'wiretap:%' and scope not like 'worker:%'", query)
 	require.Nil(t, args)
 	query, args = snapshotExportQuery("custom")
 	require.Equal(t, "select * from custom", query)
@@ -2174,7 +2176,7 @@ func TestShareSmallHelpersAndValidation(t *testing.T) {
 	require.Equal(t, "delete from message_events where guild_id != ?", query)
 	require.Equal(t, []any{directMessageGuildID}, args)
 	query, args = snapshotDeleteQuery("sync_state")
-	require.Equal(t, "delete from sync_state where scope not like 'wiretap:%'", query)
+	require.Equal(t, "delete from sync_state where scope not like 'wiretap:%' and scope not like 'worker:%'", query)
 	require.Nil(t, args)
 	query, args = snapshotDeleteQuery("custom")
 	require.Equal(t, "delete from custom", query)

--- a/internal/store/embedding_worker.go
+++ b/internal/store/embedding_worker.go
@@ -110,7 +110,11 @@ func (s *Store) NewEmbeddingWorker(ctx context.Context, provider embed.Provider,
 		return nil, err
 	}
 	q := &embeddingWorkQueue{store: s, reader: reader, opts: opts, embedProvider: provider}
-	r, err := worker.New[string, embeddingWorkResult](q, q.process, worker.Options{Kind: "embeddings", BatchSize: 64, Concurrency: 2})
+	requestTimeout := opts.RequestTimeout
+	if requestTimeout <= 0 {
+		requestTimeout = embed.DefaultRequestTimeout
+	}
+	r, err := worker.New[string, embeddingWorkResult](q, q.process, worker.Options{Kind: "embeddings", BatchSize: min(opts.BatchSize, 64), Concurrency: 2, TaskTimeout: requestTimeout + 30*time.Second})
 	if err != nil {
 		_ = reader.Close()
 		return nil, err

--- a/internal/store/embedding_worker.go
+++ b/internal/store/embedding_worker.go
@@ -1,0 +1,387 @@
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/embed"
+	crawlstore "github.com/openclaw/crawlkit/store"
+	"github.com/openclaw/crawlkit/worker"
+)
+
+func (s *Store) applyEmbeddingWorkerMigration(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	rows, err := tx.QueryContext(ctx, `pragma table_info(embedding_jobs)`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	present := map[string]bool{}
+	for rows.Next() {
+		var id, nn, pk int
+		var name, typ string
+		var def sql.NullString
+		if err = rows.Scan(&id, &name, &typ, &nn, &def, &pk); err != nil {
+			return err
+		}
+		present[name] = true
+	}
+	err = rows.Err()
+	if err != nil {
+		return err
+	}
+	for _, column := range []struct{ name, definition string }{
+		{"revision", "integer not null default 1"},
+		{"lease_token", "text not null default ''"},
+		{"lease_until", "text not null default ''"},
+		{"available_at", "text not null default ''"},
+		{"priority", "integer not null default 0"},
+		{"enqueued_at", "text not null default ''"},
+	} {
+		if !present[column.name] {
+			if _, err = tx.ExecContext(ctx, `alter table embedding_jobs add column `+column.name+` `+column.definition); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err = tx.ExecContext(ctx, `create index if not exists idx_embedding_worker_ready on embedding_jobs(priority,available_at,updated_at,message_id) where state='pending'`); err != nil {
+		return err
+	}
+	// Older pending work is catch-up. No archive scan or vector regeneration is required.
+	if _, err = tx.ExecContext(ctx, `update embedding_jobs set locked_at=null where state='pending'`); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// EmbeddingWorker uses the tail owner's existing writer connection for short
+// transactions, and a separate read-only connection for content preparation.
+type EmbeddingWorker struct {
+	queue  *embeddingWorkQueue
+	runner *worker.Runner[string, embeddingWorkResult]
+}
+type embeddingWorkQueue struct {
+	store         *Store
+	reader        *crawlstore.Store
+	opts          EmbeddingDrainOptions
+	embedProvider embed.Provider
+}
+type embeddingWorkResult struct {
+	input      string
+	valid      bool
+	blob       []byte
+	dimensions int
+	empty      bool
+}
+
+type EmbeddingWorkerStatus struct {
+	FailedJobs int `json:"failed_jobs"`
+	worker.Status
+	UpdatedAt       time.Time `json:"updated_at"`
+	Pending         int       `json:"pending"`
+	OldestPendingAt string    `json:"oldest_pending_at,omitempty"`
+}
+
+func (s *Store) NewEmbeddingWorker(ctx context.Context, provider embed.Provider, opts EmbeddingDrainOptions) (*EmbeddingWorker, error) {
+	if provider == nil {
+		return nil, errors.New("embedding worker requires a provider")
+	}
+	reader, err := crawlstore.OpenReadOnly(ctx, s.path)
+	if err != nil {
+		return nil, err
+	}
+	opts = normalizeEmbeddingDrainOptions(opts)
+	// Startup happens under the CLI's exclusive writer lock, so no previous tail
+	// owner is alive. Recover its interrupted claims immediately, without waiting
+	// the full lease interval. This method must not be used by competing processes.
+	if _, err = s.db.ExecContext(ctx, `update embedding_jobs set lease_token='',lease_until='',locked_at=null where state='pending' and (lease_token!='' or locked_at is not null)`); err != nil {
+		_ = reader.Close()
+		return nil, err
+	}
+	q := &embeddingWorkQueue{store: s, reader: reader, opts: opts, embedProvider: provider}
+	r, err := worker.New[string, embeddingWorkResult](q, q.process, worker.Options{Kind: "embeddings", BatchSize: 64, Concurrency: 2})
+	if err != nil {
+		_ = reader.Close()
+		return nil, err
+	}
+	return &EmbeddingWorker{queue: q, runner: r}, nil
+}
+
+func (w *EmbeddingWorker) Run(ctx context.Context) error {
+	defer func() { _ = w.queue.reader.Close() }()
+	w.queue.store.setEmbeddingWake(w.runner.Notify)
+	defer w.queue.store.setEmbeddingWake(nil)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.persistStatus(ctx)
+			}
+		}
+	}()
+	err := w.runner.Run(ctx)
+	<-done
+	final, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	w.persistStatus(final)
+	return err
+}
+func (w *EmbeddingWorker) Status() worker.Status { return w.runner.Status() }
+func (w *EmbeddingWorker) persistStatus(ctx context.Context) {
+	call, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	body, err := json.Marshal(EmbeddingWorkerStatus{Status: w.runner.Status(), UpdatedAt: time.Now().UTC()})
+	if err != nil {
+		return
+	}
+	_, _ = w.queue.store.db.ExecContext(call, `insert into sync_state(scope,cursor,updated_at)values('worker:embeddings',?,?) on conflict(scope)do update set cursor=excluded.cursor,updated_at=excluded.updated_at`, string(body), time.Now().UTC().Format(timeLayout))
+}
+
+func (s *Store) ReadEmbeddingWorkerStatus(ctx context.Context) (*EmbeddingWorkerStatus, error) {
+	var body string
+	err := s.db.QueryRowContext(ctx, `select cursor from sync_state where scope='worker:embeddings'`).Scan(&body)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var status EmbeddingWorkerStatus
+	if err = json.Unmarshal([]byte(body), &status); err != nil {
+		return nil, err
+	}
+	if time.Since(status.UpdatedAt) > 10*time.Second && status.State != "stopped" {
+		status.State = "stale"
+	}
+	err = s.db.QueryRowContext(ctx, `select count(*),coalesce(min(coalesce(nullif(j.enqueued_at,''),j.updated_at)),'') from embedding_jobs j join messages m on m.id=j.message_id where j.state='pending' and m.deleted_at is null and m.guild_id!='@me'`).Scan(&status.Pending, &status.OldestPendingAt)
+	if err != nil {
+		return nil, err
+	}
+	err = s.db.QueryRowContext(ctx, `select count(*) from embedding_jobs where state='failed'`).Scan(&status.FailedJobs)
+	return &status, err
+}
+
+func (q *embeddingWorkQueue) Claim(ctx context.Context, req worker.ClaimRequest) ([]worker.Job[string], error) {
+	if req.Kind != "embeddings" {
+		return nil, errors.New("unsupported worker kind")
+	}
+	priority := 1
+	if req.Class == worker.CatchUp {
+		priority = 0
+	}
+	tx, err := q.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback(tx)
+	now := req.Now.UTC().Format(timeLayout)
+	rows, err := tx.QueryContext(ctx, `select message_id,revision,attempts,provider,model,input_version from embedding_jobs where state='pending' and priority=? and available_at<=? and lease_until<=? and exists(select 1 from messages m where m.id=embedding_jobs.message_id and m.deleted_at is null and m.guild_id!='@me') order by available_at,updated_at,message_id limit ?`, priority, now, now, req.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var jobs []worker.Job[string]
+	for rows.Next() {
+		var j worker.Job[string]
+		var revision int64
+		var provider, model, inputVersion string
+		if err = rows.Scan(&j.Key, &revision, &j.Attempts, &provider, &model, &inputVersion); err != nil {
+			return nil, err
+		}
+		if provider != q.opts.Provider || model != q.opts.Model || inputVersion != q.opts.InputVersion {
+			j.Attempts = 0
+		}
+		j.Revision = strconv.FormatInt(revision, 10)
+		j.Token = rand.Text()
+		j.Payload = j.Key
+		jobs = append(jobs, j)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+	for _, j := range jobs {
+		if _, err = tx.ExecContext(ctx, `update embedding_jobs set lease_token=?,lease_until=?,locked_at=?,provider=?,model=?,input_version=?,attempts=? where message_id=? and revision=?`, j.Token, req.LeaseUntil.UTC().Format(timeLayout), now, q.opts.Provider, q.opts.Model, q.opts.InputVersion, j.Attempts, j.Key, j.Revision); err != nil {
+			return nil, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+func (q *embeddingWorkQueue) process(ctx context.Context, jobs []worker.Job[string]) ([]embeddingWorkResult, error) {
+	results := make([]embeddingWorkResult, len(jobs))
+	var inputs []string
+	var indexes []int
+	for i, j := range jobs {
+		var text string
+		err := q.reader.DB().QueryRowContext(ctx, `select m.normalized_content from messages m join embedding_jobs j on j.message_id=m.id where m.id=? and m.deleted_at is null and m.guild_id!='@me' and j.revision=? and j.lease_token=?`, j.Key, j.Revision, j.Token).Scan(&text)
+		if errors.Is(err, sql.ErrNoRows) {
+			results[i].empty = true
+			continue
+		}
+		if err != nil {
+			return nil, &worker.Failure{Code: "embedding_read_failed", Pause: true}
+		}
+		results[i].input = capRunes(text, q.opts.MaxInputChars)
+		results[i].valid = true
+		if strings.TrimSpace(text) == "" {
+			results[i].empty = true
+			continue
+		}
+		inputs = append(inputs, capRunes(text, q.opts.MaxInputChars))
+		indexes = append(indexes, i)
+	}
+	if len(inputs) == 0 {
+		return results, nil
+	}
+	batch, err := q.embedProvider.Embed(ctx, inputs)
+	if err != nil {
+		return nil, embeddingWorkerFailure(err)
+	}
+	dimensions, err := validateEmbeddingBatch(batch, len(inputs))
+	if err != nil {
+		return nil, &worker.Failure{Code: "invalid_embedding_response", Permanent: true}
+	}
+	for k, i := range indexes {
+		blob, err := EncodeEmbeddingVector(batch.Vectors[k])
+		if err != nil {
+			return nil, &worker.Failure{Code: "invalid_embedding_vector", Permanent: true}
+		}
+		results[i].blob = blob
+		results[i].dimensions = dimensions
+	}
+	return results, nil
+}
+
+func embeddingWorkerFailure(err error) error {
+	if classified, ok := errors.AsType[*worker.Failure](err); ok {
+		return classified
+	}
+	if h, ok := errors.AsType[*embed.HTTPError](err); ok {
+		f := &worker.Failure{Code: "embedding_http_" + strconv.Itoa(h.StatusCode)}
+		f.Pause = h.StatusCode == http.StatusUnauthorized || h.StatusCode == http.StatusForbidden || h.StatusCode == http.StatusTooManyRequests || h.StatusCode >= 500
+		f.Permanent = !f.Pause
+		if seconds, e := strconv.Atoi(h.Header.Get("Retry-After")); e == nil && seconds > 0 {
+			f.RetryAfter = time.Duration(seconds) * time.Second
+		} else if at, e := http.ParseTime(h.Header.Get("Retry-After")); e == nil {
+			f.RetryAfter = time.Until(at)
+		}
+		if f.Pause && f.RetryAfter <= 0 {
+			f.RetryAfter = 5 * time.Second
+		}
+		return f
+	}
+	return &worker.Failure{Code: "embedding_provider_unavailable", Pause: true, RetryAfter: 5 * time.Second}
+}
+
+func (q *embeddingWorkQueue) Complete(ctx context.Context, j worker.Job[string], r embeddingWorkResult, now time.Time) (bool, error) {
+	tx, err := q.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer rollback(tx)
+	n, err := tx.ExecContext(ctx, `update embedding_jobs set state='done',attempts=0,last_error='',locked_at=null,lease_token='',lease_until='',available_at='',updated_at=? where message_id=? and revision=? and lease_token=? and lease_until>? and state='pending'`, now.UTC().Format(timeLayout), j.Key, j.Revision, j.Token, now.UTC().Format(timeLayout))
+	if err != nil {
+		return false, err
+	}
+	affected, err := n.RowsAffected()
+	if err != nil || affected == 0 {
+		return false, err
+	}
+	var current string
+	err = tx.QueryRowContext(ctx, `select normalized_content from messages where id=? and deleted_at is null and guild_id!='@me'`, j.Key).Scan(&current)
+	if errors.Is(err, sql.ErrNoRows) {
+		if _, err = tx.ExecContext(ctx, `delete from embedding_jobs where message_id=?`, j.Key); err != nil {
+			return false, err
+		}
+		if _, err = tx.ExecContext(ctx, `delete from message_embeddings where message_id=?`, j.Key); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	}
+	if err != nil {
+		return false, err
+	}
+	if !r.valid || capRunes(current, q.opts.MaxInputChars) != r.input {
+		if _, err = tx.ExecContext(ctx, `update embedding_jobs set state='pending',revision=revision+1,priority=1,enqueued_at=? where message_id=?`, now.UTC().Format(timeLayout), j.Key); err != nil {
+			return false, err
+		}
+		if _, err = tx.ExecContext(ctx, `delete from message_embeddings where message_id=?`, j.Key); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	}
+	if r.empty {
+		_, err = tx.ExecContext(ctx, `delete from message_embeddings where message_id=?`, j.Key)
+	} else {
+		_, err = tx.ExecContext(ctx, `insert into message_embeddings(message_id,provider,model,input_version,dimensions,embedding_blob,embedded_at)values(?,?,?,?,?,?,?) on conflict(message_id,provider,model,input_version)do update set dimensions=excluded.dimensions,embedding_blob=excluded.embedding_blob,embedded_at=excluded.embedded_at`, j.Key, q.opts.Provider, q.opts.Model, q.opts.InputVersion, r.dimensions, r.blob, now.UTC().Format(timeLayout))
+	}
+	if err != nil {
+		return false, err
+	}
+	if err = tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (q *embeddingWorkQueue) Retry(ctx context.Context, j worker.Job[string], r worker.Retry) (bool, error) {
+	state := "pending"
+	if r.Permanent {
+		state = "failed"
+	}
+	inc := 0
+	if r.CountAttempt {
+		inc = 1
+	}
+	result, err := q.store.db.ExecContext(ctx, `update embedding_jobs set state=?,attempts=attempts+?,last_error=?,locked_at=null,lease_token='',lease_until='',available_at=?,updated_at=? where message_id=? and revision=? and lease_token=? and lease_until>? and state='pending'`, state, inc, r.Code, r.At.UTC().Format(timeLayout), r.Now.UTC().Format(timeLayout), j.Key, j.Revision, j.Token, r.Now.UTC().Format(timeLayout))
+	if err != nil {
+		return false, err
+	}
+	n, err := result.RowsAffected()
+	return n == 1, err
+}
+
+func (q *embeddingWorkQueue) Release(ctx context.Context, j worker.Job[string], now time.Time) (bool, error) {
+	result, err := q.store.db.ExecContext(ctx, `update embedding_jobs set locked_at=null,lease_token='',lease_until='' where message_id=? and revision=? and lease_token=? and lease_until>? and state='pending'`, j.Key, j.Revision, j.Token, now.UTC().Format(timeLayout))
+	if err != nil {
+		return false, err
+	}
+	n, err := result.RowsAffected()
+	return n == 1, err
+}
+
+func (s *Store) setEmbeddingWake(wake func()) {
+	s.embeddingWakeMu.Lock()
+	defer s.embeddingWakeMu.Unlock()
+	s.embeddingWake = wake
+}
+
+func (s *Store) notifyEmbeddingWork() {
+	s.embeddingWakeMu.RLock()
+	wake := s.embeddingWake
+	s.embeddingWakeMu.RUnlock()
+	if wake != nil {
+		wake()
+	}
+}

--- a/internal/store/embedding_worker_test.go
+++ b/internal/store/embedding_worker_test.go
@@ -1,0 +1,379 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crawlkit/embed"
+	"github.com/openclaw/crawlkit/worker"
+	"github.com/stretchr/testify/require"
+)
+
+type liveTestProvider func(context.Context, []string) (embed.EmbeddingBatch, error)
+
+func (f liveTestProvider) Embed(ctx context.Context, input []string) (embed.EmbeddingBatch, error) {
+	return f(ctx, input)
+}
+
+func liveVectors(_ context.Context, input []string) (embed.EmbeddingBatch, error) {
+	v := make([][]float32, len(input))
+	for i := range v {
+		v[i] = []float32{float32(len(input[i])), 1}
+	}
+	return embed.EmbeddingBatch{Vectors: v}, nil
+}
+
+func liveStore(t *testing.T) *Store {
+	t.Helper()
+	s, e := Open(t.Context(), filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, e)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func liveOpts() EmbeddingDrainOptions {
+	return EmbeddingDrainOptions{Provider: "openai", Model: "fixture", InputVersion: EmbeddingInputVersion}
+}
+
+func liveMessage(t *testing.T, s *Store, id, text string) {
+	t.Helper()
+	require.NoError(t, s.UpsertMessageWithOptions(t.Context(), MessageRecord{ID: id, GuildID: "g", ChannelID: "c", Content: text, NormalizedContent: text, CreatedAt: time.Now().UTC().Format(time.RFC3339)}, WriteOptions{EnqueueEmbedding: true}))
+}
+
+func makeLiveWorker(t *testing.T, s *Store, p embed.Provider) *EmbeddingWorker {
+	t.Helper()
+	w, e := s.NewEmbeddingWorker(t.Context(), p, liveOpts())
+	require.NoError(t, e)
+	t.Cleanup(func() { _ = w.queue.reader.Close() })
+	return w
+}
+
+func startLive(t *testing.T, w *EmbeddingWorker) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case e := <-done:
+			require.NoError(t, e)
+		case <-time.After(5 * time.Second):
+			t.Error("worker did not stop")
+		}
+	})
+	return cancel
+}
+
+func claimLive(t *testing.T, q *embeddingWorkQueue, class worker.Class) worker.Job[string] {
+	t.Helper()
+	now := time.Now().UTC()
+	jobs, e := q.Claim(t.Context(), worker.ClaimRequest{Kind: "embeddings", Class: class, Limit: 1, Now: now, LeaseUntil: now.Add(time.Minute)})
+	require.NoError(t, e)
+	require.Len(t, jobs, 1)
+	return jobs[0]
+}
+
+func TestEmbeddingWorkerMigrationPreservesExistingArchive(t *testing.T) {
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "old.db")
+	db, e := sql.Open("sqlite", path)
+	require.NoError(t, e)
+	old := &Store{db: db, path: path}
+	require.NoError(t, old.applyBaselineSchema(ctx))
+	require.NoError(t, old.setSchemaVersion(ctx, 5))
+	_, e = db.ExecContext(t.Context(), `insert into embedding_jobs(message_id,state,attempts,updated_at)values('old','pending',2,'2026-01-01')`)
+	require.NoError(t, e)
+	require.NoError(t, db.Close())
+	s, e := Open(ctx, path)
+	require.NoError(t, e)
+	defer func() { _ = s.Close() }()
+	version, e := s.schemaVersion(ctx)
+	require.NoError(t, e)
+	require.Equal(t, 6, version)
+	var priority, revision, attempts int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select priority,revision,attempts from embedding_jobs where message_id='old'`).Scan(&priority, &revision, &attempts))
+	require.Equal(t, 0, priority)
+	require.Equal(t, 1, revision)
+	require.Equal(t, 2, attempts)
+	require.NoError(t, s.applyEmbeddingWorkerMigration(ctx))
+}
+
+func TestEmbeddingWorkerFencesEditsDeletesAndLeaseExpiry(t *testing.T) {
+	s := liveStore(t)
+	w := makeLiveWorker(t, s, liveTestProvider(liveVectors))
+	q := w.queue
+	ctx := t.Context()
+	liveMessage(t, s, "101", "old")
+	j := claimLive(t, q, worker.Fresh)
+	result, e := q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	liveMessage(t, s, "101", "new")
+	ok, e := q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	ok, e = q.Retry(ctx, j, worker.Retry{Now: time.Now(), At: time.Now(), Permanent: true})
+	require.NoError(t, e)
+	require.False(t, ok)
+	ok, e = q.Release(ctx, j, time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	current := claimLive(t, q, worker.Fresh)
+	result, e = q.process(ctx, []worker.Job[string]{current})
+	require.NoError(t, e)
+	ok, e = q.Complete(ctx, current, result[0], time.Now().Add(2*time.Minute))
+	require.NoError(t, e)
+	require.False(t, ok)
+	ok, e = q.Complete(ctx, current, result[0], time.Now())
+	require.NoError(t, e)
+	require.True(t, ok)
+	ok, e = q.Complete(ctx, current, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	var count int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select count(*) from message_embeddings where message_id='101'`).Scan(&count))
+	require.Equal(t, 1, count)
+	liveMessage(t, s, "101", "third")
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select count(*) from message_embeddings where message_id='101'`).Scan(&count))
+	require.Zero(t, count)
+	j = claimLive(t, q, worker.Fresh)
+	result, e = q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	require.NoError(t, s.MarkMessageDeletedWithoutEvent(ctx, "g", "c", "101"))
+	ok, e = q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	liveMessage(t, s, "101", "resurrected")
+	ok, e = q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+}
+
+func TestEmbeddingWorkerDetectsUnqueuedSourceChangesAndPrivacy(t *testing.T) {
+	s := liveStore(t)
+	w := makeLiveWorker(t, s, liveTestProvider(liveVectors))
+	ctx := t.Context()
+	q := w.queue
+	liveMessage(t, s, "101", "old")
+	j := claimLive(t, q, worker.Fresh)
+	result, e := q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	_, e = s.db.ExecContext(t.Context(), `update messages set normalized_content='external update' where id='101'`)
+	require.NoError(t, e)
+	ok, e := q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	j = claimLive(t, q, worker.Fresh)
+	result, e = q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	_, e = s.db.ExecContext(t.Context(), `update messages set guild_id='@me' where id='101'`)
+	require.NoError(t, e)
+	ok, e = q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.False(t, ok)
+	var count int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select count(*) from embedding_jobs`).Scan(&count))
+	require.Zero(t, count)
+	liveMessage(t, s, "102", " ")
+	j = claimLive(t, q, worker.Fresh)
+	result, e = q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	require.True(t, result[0].empty)
+	ok, e = q.Complete(ctx, j, result[0], time.Now())
+	require.NoError(t, e)
+	require.True(t, ok)
+	liveMessage(t, s, "103", "next")
+	j = claimLive(t, q, worker.Fresh)
+	liveMessage(t, s, "103", "updated")
+	result, e = q.process(ctx, []worker.Job[string]{j})
+	require.NoError(t, e)
+	require.False(t, result[0].valid)
+}
+
+func TestEmbeddingWorkerRestartRecoversAndFailuresAreDurable(t *testing.T) {
+	s := liveStore(t)
+	w := makeLiveWorker(t, s, liveTestProvider(liveVectors))
+	q := w.queue
+	ctx := t.Context()
+	liveMessage(t, s, "101", "text")
+	old := claimLive(t, q, worker.Fresh)
+	// Simulate a dead owner, before starting any goroutine. The CLI's writer lock
+	// guarantees this recovery never competes with another live tail process.
+	restarted := makeLiveWorker(t, s, liveTestProvider(liveVectors))
+	j := claimLive(t, restarted.queue, worker.Fresh)
+	require.NotEqual(t, old.Token, j.Token)
+	ok, e := q.Retry(ctx, old, worker.Retry{Now: time.Now(), At: time.Now()})
+	require.NoError(t, e)
+	require.False(t, ok)
+	now := time.Now()
+	ok, e = restarted.queue.Retry(ctx, j, worker.Retry{Now: now, At: now.Add(time.Hour), Code: "throttled"})
+	require.NoError(t, e)
+	require.True(t, ok)
+	jobs, e := q.Claim(ctx, worker.ClaimRequest{Kind: "embeddings", Class: worker.Fresh, Limit: 10, Now: now, LeaseUntil: now.Add(time.Minute)})
+	require.NoError(t, e)
+	require.Empty(t, jobs)
+	_, e = s.db.ExecContext(t.Context(), `update embedding_jobs set available_at='' where message_id='101'`)
+	require.NoError(t, e)
+	j = claimLive(t, q, worker.Fresh)
+	ok, e = q.Retry(ctx, j, worker.Retry{Now: time.Now(), At: time.Now(), Code: "invalid_input", Permanent: true, CountAttempt: true})
+	require.NoError(t, e)
+	require.True(t, ok)
+	var attempts int
+	var state string
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select attempts,state from embedding_jobs where message_id='101'`).Scan(&attempts, &state))
+	require.Equal(t, 1, attempts)
+	require.Equal(t, "failed", state)
+	liveMessage(t, s, "101", "changed")
+	j = claimLive(t, q, worker.Fresh)
+	ok, e = q.Release(ctx, j, time.Now())
+	require.NoError(t, e)
+	require.True(t, ok)
+	_, e = q.Claim(ctx, worker.ClaimRequest{Kind: "wrong"})
+	require.Error(t, e)
+}
+
+func TestEmbeddingWorkerProviderOutageDoesNotBlockIngestion(t *testing.T) {
+	s := liveStore(t)
+	entered := make(chan struct{}, 2)
+	w := makeLiveWorker(t, s, liveTestProvider(func(ctx context.Context, text []string) (embed.EmbeddingBatch, error) {
+		entered <- struct{}{}
+		<-ctx.Done()
+		return embed.EmbeddingBatch{}, ctx.Err()
+	}))
+	liveMessage(t, s, "101", "slow request")
+	cancel := startLive(t, w)
+	<-entered
+	start := time.Now()
+	liveMessage(t, s, "102", "still collecting")
+	require.Less(t, time.Since(start), time.Second)
+	cancel()
+	require.Eventually(t, func() bool { return w.Status().State == "stopped" }, 3*time.Second, time.Millisecond)
+	var status *EmbeddingWorkerStatus
+	require.Eventually(t, func() bool {
+		var err error
+		status, err = s.ReadEmbeddingWorkerStatus(t.Context())
+		return err == nil && status != nil && status.State == "stopped"
+	}, 3*time.Second, time.Millisecond)
+	require.Equal(t, 2, status.Pending)
+}
+
+func TestEmbeddingWorkerFreshnessUnderCatchup(t *testing.T) {
+	s := liveStore(t)
+	for i := range 256 {
+		liveMessage(t, s, strconv.Itoa(1000+i), "history")
+	}
+	_, e := s.db.ExecContext(t.Context(), `update embedding_jobs set priority=0`)
+	require.NoError(t, e)
+	w := makeLiveWorker(t, s, liveTestProvider(func(ctx context.Context, text []string) (embed.EmbeddingBatch, error) {
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-ctx.Done():
+			return embed.EmbeddingBatch{}, ctx.Err()
+		}
+		return liveVectors(ctx, text)
+	}))
+	startLive(t, w)
+	var mu sync.Mutex
+	latencies := map[string]time.Time{}
+	for i := range 40 {
+		id := strconv.Itoa(2000 + i)
+		start := time.Now()
+		liveMessage(t, s, id, "fresh content")
+		require.Less(t, time.Since(start), time.Second)
+		mu.Lock()
+		latencies[id] = start
+		mu.Unlock()
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.Eventually(t, func() bool {
+		var n int
+		_ = s.db.QueryRowContext(t.Context(), `select count(*) from message_embeddings where message_id>='2000'`).Scan(&n)
+		return n == 40
+	}, 10*time.Second, 20*time.Millisecond)
+	var ages []time.Duration
+	rows, e := s.db.QueryContext(t.Context(), `select message_id,embedded_at from message_embeddings where message_id>='2000'`)
+	require.NoError(t, e)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id, stamp string
+		require.NoError(t, rows.Scan(&id, &stamp))
+		at, e := time.Parse(timeLayout, stamp)
+		require.NoError(t, e)
+		ages = append(ages, at.Sub(latencies[id]))
+	}
+	require.NoError(t, rows.Err())
+
+	slices.Sort(ages)
+	p95 := ages[int(float64(len(ages)-1)*.95)]
+	t.Logf("freshness p95=%s; 10 messages/second; provider=200ms; catch-up=256", p95)
+	require.Less(t, p95, 10*time.Second)
+}
+
+func TestEmbeddingWorkerFailureClassification(t *testing.T) {
+	classify := func(err error) *worker.Failure {
+		t.Helper()
+		f, ok := errors.AsType[*worker.Failure](err)
+		require.True(t, ok)
+		return f
+	}
+	for _, code := range []int{400, 401, 403, 429, 500} {
+		f := classify(embeddingWorkerFailure(&embed.HTTPError{StatusCode: code, Header: http.Header{"Retry-After": []string{"12"}}}))
+		require.Equal(t, 12*time.Second, f.RetryAfter)
+		require.Equal(t, code != 400, f.Pause)
+	}
+	f := classify(embeddingWorkerFailure(&embed.HTTPError{StatusCode: 429, Header: http.Header{"Retry-After": []string{time.Now().Add(time.Minute).UTC().Format(http.TimeFormat)}}}))
+	require.Positive(t, f.RetryAfter)
+	f = classify(embeddingWorkerFailure(&embed.HTTPError{StatusCode: 503}))
+	require.Equal(t, 5*time.Second, f.RetryAfter)
+	require.True(t, classify(embeddingWorkerFailure(errors.New("private provider body"))).Pause)
+	original := &worker.Failure{Code: "configuration", Pause: true}
+	require.Same(t, original, embeddingWorkerFailure(original))
+	s := liveStore(t)
+	_, e := s.NewEmbeddingWorker(t.Context(), nil, liveOpts())
+	require.Error(t, e)
+	for _, provider := range []liveTestProvider{func(context.Context, []string) (embed.EmbeddingBatch, error) {
+		return embed.EmbeddingBatch{}, errors.New("private")
+	}, func(context.Context, []string) (embed.EmbeddingBatch, error) { return embed.EmbeddingBatch{}, nil }} {
+		w := makeLiveWorker(t, s, provider)
+		liveMessage(t, s, "101", "input")
+		j := claimLive(t, w.queue, worker.Fresh)
+		_, e = w.queue.process(t.Context(), []worker.Job[string]{j})
+		require.Error(t, e)
+	}
+}
+
+func TestEmbeddingWorkerCatchupPromotesLiveEdits(t *testing.T) {
+	s := liveStore(t)
+	ctx := t.Context()
+	msg := MessageRecord{ID: "101", GuildID: "g", ChannelID: "c", Content: "history", NormalizedContent: "history"}
+	require.NoError(t, s.UpsertMessageWithOptions(ctx, msg, WriteOptions{EnqueueEmbedding: true, EmbeddingCatchUp: true}))
+	var priority, revision int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select priority,revision from embedding_jobs where message_id='101'`).Scan(&priority, &revision))
+	require.Zero(t, priority)
+	liveMessage(t, s, "101", "live edit")
+	var next int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select priority,revision from embedding_jobs where message_id='101'`).Scan(&priority, &next))
+	require.Equal(t, 1, priority)
+	require.Greater(t, next, revision)
+}
+
+func TestEmbeddingWorkerProviderChangeResetsAttempts(t *testing.T) {
+	s := liveStore(t)
+	w := makeLiveWorker(t, s, liveTestProvider(liveVectors))
+	liveMessage(t, s, "101", "input")
+	_, err := s.db.ExecContext(t.Context(), `update embedding_jobs set attempts=2,provider='old',model='old',input_version='old' where message_id='101'`)
+	require.NoError(t, err)
+	job := claimLive(t, w.queue, worker.Fresh)
+	require.Zero(t, job.Attempts)
+	var attempts int
+	require.NoError(t, s.db.QueryRowContext(t.Context(), `select attempts from embedding_jobs where message_id='101'`).Scan(&attempts))
+	require.Zero(t, attempts)
+}

--- a/internal/store/embedding_worker_test.go
+++ b/internal/store/embedding_worker_test.go
@@ -377,3 +377,44 @@ func TestEmbeddingWorkerProviderChangeResetsAttempts(t *testing.T) {
 	require.NoError(t, s.db.QueryRowContext(t.Context(), `select attempts from embedding_jobs where message_id='101'`).Scan(&attempts))
 	require.Zero(t, attempts)
 }
+
+func TestEmbeddingWorkerHonorsBatchAndProviderTimeout(t *testing.T) {
+	s := liveStore(t)
+	for i := range 8 {
+		liveMessage(t, s, strconv.Itoa(100+i), "input")
+	}
+	type request struct {
+		size   int
+		budget time.Duration
+	}
+	requests := make(chan request, 8)
+	provider := liveTestProvider(func(ctx context.Context, input []string) (embed.EmbeddingBatch, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return embed.EmbeddingBatch{}, errors.New("missing deadline")
+		}
+		requests <- request{len(input), time.Until(deadline)}
+		return liveVectors(ctx, input)
+	})
+	opts := liveOpts()
+	opts.BatchSize = 2
+	opts.RequestTimeout = 5 * time.Minute
+	w, err := s.NewEmbeddingWorker(t.Context(), provider, opts)
+	require.NoError(t, err)
+	cancel := startLive(t, w)
+	require.Eventually(t, func() bool {
+		var n int
+		_ = s.db.QueryRowContext(t.Context(), `select count(*) from message_embeddings`).Scan(&n)
+		return n == 8
+	}, 5*time.Second, 20*time.Millisecond)
+	cancel()
+	require.Eventually(t, func() bool { return w.Status().State == "stopped" }, time.Second, time.Millisecond)
+	close(requests)
+	count := 0
+	for r := range requests {
+		count++
+		require.LessOrEqual(t, r.size, 2)
+		require.Greater(t, r.budget, 5*time.Minute)
+	}
+	require.GreaterOrEqual(t, count, 4)
+}

--- a/internal/store/embeddings.go
+++ b/internal/store/embeddings.go
@@ -21,13 +21,14 @@ const (
 )
 
 type EmbeddingDrainOptions struct {
-	Provider      string
-	Model         string
-	InputVersion  string
-	Limit         int
-	BatchSize     int
-	MaxInputChars int
-	Now           func() time.Time
+	RequestTimeout time.Duration
+	Provider       string
+	Model          string
+	InputVersion   string
+	Limit          int
+	BatchSize      int
+	MaxInputChars  int
+	Now            func() time.Time
 }
 
 type EmbeddingDrainStats struct {

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -894,6 +894,10 @@ func (s *Store) Status(ctx context.Context, dbPath, defaultGuildID string) (Stat
 		return Status{}, err
 	}
 	status.AccessibleGuildIDs = guildIDs
+	status.BackgroundWork, err = s.ReadEmbeddingWorkerStatus(ctx)
+	if err != nil {
+		return Status{}, err
+	}
 	return status, nil
 }
 

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -123,7 +123,13 @@ create table embedding_jobs (
 	input_version text not null default '',
 	last_error text not null default '',
 	locked_at text,
-	updated_at text not null
+	updated_at text not null,
+	revision integer not null default 1,
+	lease_token text not null default '',
+	lease_until text not null default '',
+	available_at text not null default '',
+	priority integer not null default 0,
+	enqueued_at text not null default ''
 );
 
 create table message_embeddings (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
+	"sync"
 	"time"
 
 	crawlstore "github.com/openclaw/crawlkit/store"
@@ -17,12 +18,14 @@ const (
 	timeLayout         = "2006-01-02T15:04:05.000000000Z07:00"
 	messageFTSVersion  = "2"
 	memberFTSVersion   = "1"
-	storeSchemaVersion = 5
+	storeSchemaVersion = 6
 )
 
 var ErrSchemaVersionMismatch = errors.New("database schema version mismatch")
 
 type Store struct {
+	embeddingWakeMu   sync.RWMutex
+	embeddingWake     func()
 	db                *sql.DB
 	q                 *storedb.Queries
 	path              string
@@ -46,18 +49,19 @@ const (
 )
 
 type Status struct {
-	DBPath             string    `json:"db_path"`
-	GuildCount         int       `json:"guild_count"`
-	ChannelCount       int       `json:"channel_count"`
-	ThreadCount        int       `json:"thread_count"`
-	MessageCount       int       `json:"message_count"`
-	MemberCount        int       `json:"member_count"`
-	EmbeddingBacklog   int       `json:"embedding_backlog"`
-	LastSyncAt         time.Time `json:"last_sync_at,omitzero"`
-	LastTailEventAt    time.Time `json:"last_tail_event_at,omitzero"`
-	DefaultGuildID     string    `json:"default_guild_id,omitempty"`
-	DefaultGuildName   string    `json:"default_guild_name,omitempty"`
-	AccessibleGuildIDs []string  `json:"accessible_guild_ids,omitempty"`
+	BackgroundWork     *EmbeddingWorkerStatus `json:"background_work,omitempty"`
+	DBPath             string                 `json:"db_path"`
+	GuildCount         int                    `json:"guild_count"`
+	ChannelCount       int                    `json:"channel_count"`
+	ThreadCount        int                    `json:"thread_count"`
+	MessageCount       int                    `json:"message_count"`
+	MemberCount        int                    `json:"member_count"`
+	EmbeddingBacklog   int                    `json:"embedding_backlog"`
+	LastSyncAt         time.Time              `json:"last_sync_at,omitzero"`
+	LastTailEventAt    time.Time              `json:"last_tail_event_at,omitzero"`
+	DefaultGuildID     string                 `json:"default_guild_id,omitempty"`
+	DefaultGuildName   string                 `json:"default_guild_name,omitempty"`
+	AccessibleGuildIDs []string               `json:"accessible_guild_ids,omitempty"`
 }
 
 type SearchOptions struct {
@@ -245,6 +249,17 @@ func (s *Store) migrate(ctx context.Context) error {
 			return err
 		}
 		if err := s.setSchemaVersion(ctx, 5); err != nil {
+			return err
+		}
+	}
+	if currentVersion < 6 {
+		if err := s.applyQueryIndexMigration(ctx); err != nil {
+			return err
+		}
+		if err := s.applyEmbeddingWorkerMigration(ctx); err != nil {
+			return err
+		}
+		if err := s.setSchemaVersion(ctx, 6); err != nil {
 			return err
 		}
 	}

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -36,6 +36,12 @@ type EmbeddingJob struct {
 	LastError    string
 	LockedAt     sql.NullString
 	UpdatedAt    string
+	Revision     int64
+	LeaseToken   string
+	LeaseUntil   string
+	AvailableAt  string
+	Priority     int64
+	EnqueuedAt   string
 }
 
 type FailureLedger struct {

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -113,6 +113,7 @@ type MessageMutation struct {
 type WriteOptions struct {
 	AppendEvent      bool
 	EnqueueEmbedding bool
+	EmbeddingCatchUp bool
 	PreserveNewer    bool
 	DeduplicateEvent bool
 }
@@ -282,7 +283,11 @@ func (s *Store) UpsertMessageWithOptions(ctx context.Context, message MessageRec
 	if err := s.upsertMessageTx(ctx, tx, s.q.WithTx(tx), message, opts); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.notifyEmbeddingWork()
+	return nil
 }
 
 func (s *Store) UpsertMessages(ctx context.Context, messages []MessageMutation) error {
@@ -342,7 +347,11 @@ func (s *Store) UpsertMessages(ctx context.Context, messages []MessageMutation) 
 			}
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.notifyEmbeddingWork()
+	return nil
 }
 
 func keepStoredMessage(ctx context.Context, qtx *storedb.Queries, message MessageRecord) (bool, error) {
@@ -431,6 +440,16 @@ func (s *Store) upsertMessageTx(
 		(errors.Is(previousErr, sql.ErrNoRows) || previousNormalized.String != message.NormalizedContent || !jobExists)
 	if queueEmbedding {
 		if err := qtx.UpsertEmbeddingJobPending(ctx, storedb.UpsertEmbeddingJobPendingParams{MessageID: message.ID, UpdatedAt: now}); err != nil {
+			return err
+		}
+		priority := 1
+		if opts.EmbeddingCatchUp {
+			priority = 0
+		}
+		if _, err := tx.ExecContext(ctx, `update embedding_jobs set revision=revision+1,lease_token='',lease_until='',available_at='',priority=?,enqueued_at=? where message_id=?`, priority, now, message.ID); err != nil {
+			return err
+		}
+		if err := qtx.DeleteMessageEmbeddingsByMessage(ctx, message.ID); err != nil {
 			return err
 		}
 	}

--- a/internal/syncer/message_sync.go
+++ b/internal/syncer/message_sync.go
@@ -790,6 +790,7 @@ func buildMessageMutations(ctx context.Context, messages []*discordgo.Message, c
 		if err != nil {
 			return nil, "", err
 		}
+		mutation.Options.EmbeddingCatchUp = true
 		mutations = append(mutations, mutation)
 		newest = maxSnowflake(newest, message.ID)
 	}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

Related: openclaw/crawlkit#115

## What Problem This Solves

Fixes an issue where users running continuous Discord capture could not also keep embeddings current without an external stop/embed/restart cycle. The standalone commands both need the archive's exclusive writer ownership, while queued content can remain unembedded until the next scheduled drain.

## Why This Change Was Made

Add opt-in `tail --embed-live`, backed by the general worker runtime in published crawlkit v0.16.0. Capture and embedding share one process owner, with provider calls outside transactions, separate read-only preparation, and short result commits. Revision/lease fencing discards stale work after edits, deletes, or claim recovery. Fresh Gateway work takes priority over historical sync catch-up.

## User Impact

- With configured embeddings, `tail --embed-live` queues and continuously processes content. Existing `--with-embeddings` remains queue-only and the one-shot `embed` command remains available.
- Provider outages, missing credentials and throttling pause processing while capture continues. Status adds local-only background-worker state, backlog age, pending/in-flight work and safe error codes.
- Material queued edits invalidate old vectors while their replacements are pending. Late results cannot resurrect deleted/private content or overwrite newer input.
- Every writable archive open migrates schema 5 to 6, including when live mode is disabled. This intentional versioned migration adds queue fields and an index and preserves messages and vectors. Older binaries reject schema 6. The supported feature rollback retains the new binary and restores queue-only capture plus one-shot embedding, which remain covered by the CLI tests; it never overwrites newly captured data with a pre-upgrade database.

## Evidence

- Full Go race suite passed, using `init.defaultBranch=master` to match the existing publishing fixture's Linux CI behavior. Focused migration, concurrency, lease recovery, edit/delete, credential failure and fairness tests pass.
- Provider-specific batch sizes are honored below the 64-input ceiling; the worker deadline and lease include the configured provider timeout. Focused non-default batch/timeout regressions pass.
- Lint and vet pass. Overall measured statement coverage exceeds the repository's 85% floor.
- A 10-message/second test with 256 catch-up jobs and a simulated 200 ms provider measured embedding freshness p95 around 0.62 seconds, below the 10-second target.
- A migration preflight on a copied 15 GB archive completed in 8.64 seconds and preserved message, vector and job-state counts. The live store was not used for tests.
- crawlkit v0.16.0 is available through the public Go proxy; no local module replacement is committed.
