### PR TITLE
fix: prevent live-embedding shutdown delays during storage failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Use CrawlKit v0.16.1 to bound live-embedding shutdown when cancellation interrupts retry or completion persistence and cleanup storage is unavailable.
 - Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, separate markers preserving legacy narrative notes, explicit timestamp and coverage limits, and filtered-publication cleanup.
 
 ## 0.14.1 - 2026-09-09

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/openclaw/crawlkit v0.16.0
+	github.com/openclaw/crawlkit v0.16.1
 	github.com/stretchr/testify v1.12.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.16.0 h1:zLjLAWqJR9KM2U50nQ+yCAxiCJ/tnayDgPs4UanEi+I=
-github.com/openclaw/crawlkit v0.16.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
+github.com/openclaw/crawlkit v0.16.1 h1:O3tieu+RU7Z6uXTUhqgjeQejaK3Z13x6+CEzV35LiQc=
+github.com/openclaw/crawlkit v0.16.1/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

Related: #217 and openclaw/crawlkit#117.

## What Problem This Solves

Fixes an issue where users stopping `tail --embed-live` could wait over five minutes when cancellation interrupted saving retries and cleanup storage was unavailable. Discrawl inherited the worker shutdown defect in crawlkit v0.16.0.

## Why This Change Was Made

Consume published crawlkit v0.16.1, which stops retry persistence after cancellation and shares one cleanup deadline across unfinished claims. The patch also bounds interrupted completion and rejected-batch cleanup. This dependency update requires no new database migration or configuration.

## User Impact

Live embedding can shut down promptly during storage failures. Claims that cannot be released remain recoverable through their existing leases.

## Evidence

- The upstream regression reproduces 320 seconds before the fix and five seconds after at default limits, using a controlled clock; all 16 cases pass.
- Crawlkit #117 passed full tests, race tests, downstream compatibility, and ClawSweeper review with no outstanding findings.
- Public Go proxy and module checksum verification passed; the downloaded worker source matches the reviewed fix byte-for-byte.
- The full Discrawl race suite passed against published v0.16.1. The existing publishing fixture used Git init.defaultBranch=master to match Linux CI; no application workaround was added.
- Vet and module tidy passed. Structured autoreview completed with no actionable findings.
