### PR TITLE
feat: recover restart gaps when tail connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Use CrawlKit v0.16.1 to bound live-embedding shutdown when cancellation interrupts retry or completion persistence and cleanup storage is unavailable.
 - Generate deterministic, aggregate-only Discord field notes alongside daily published activity reports, with paired Markdown/JSON artifacts, separate markers preserving legacy narrative notes, explicit timestamp and coverage limits, and filtered-publication cleanup.
 
+- Add opt-in `tail --repair-on-start` to recover restart gaps immediately after Gateway connection, using the existing serialized repair and writer ownership.
+
 ## 0.14.1 - 2026-09-09
 
 - Accept the application's legacy migrated attachment column order in the backup-first repair helper while retaining exact schema and repair safeguards.

--- a/docs/commands/tail.md
+++ b/docs/commands/tail.md
@@ -11,6 +11,7 @@ discrawl tail --with-embeddings
 discrawl tail --embed-live
 discrawl tail --guild 123456789012345678
 discrawl tail --repair-every 30m
+discrawl tail --repair-on-start --repair-every 6h
 discrawl tail --replay-failures-only
 ```
 
@@ -28,6 +29,7 @@ discrawl tail --replay-failures-only
 
 - `--guild <id>` / `--guilds <id,id>` - tail a specific guild scope (default: `default_guild_id`, or all discovered guilds if unset)
 - `--repair-every <duration>` - frequency of the repair sweep
+- `--repair-on-start` - run one catch-up repair after the Gateway connects, without waiting for the periodic timer (default: off; also works with `--repair-every 0`)
 - `--embed-live` - continuously process queued embeddings while capture continues (opt-in; implies queueing; requires configured embeddings)
 - `--with-embeddings` - queue live, replayed, and repair messages for embedding (default: off)
 - `--replay-failures-only` - replay unresolved exact-message tail failures and exit
@@ -36,6 +38,7 @@ discrawl tail --replay-failures-only
 ## Notes
 
 - requires a working Discord bot token
+- startup repair uses the same writer owner and serialized repair lifecycle as periodic repair; capture remains connected while missed history is fetched, and shutdown cancels and joins the repair
 - not available in Git-only mode (`discord.token_source = "none"`)
 - `discrawl --verbose tail` traces Gateway receipt, worker handling, scope
   filtering, and successful archive writes with event and Discord IDs but no

--- a/docs/commands/tail.md
+++ b/docs/commands/tail.md
@@ -39,6 +39,7 @@ discrawl tail --replay-failures-only
 
 - requires a working Discord bot token
 - startup repair uses the same writer owner and serialized repair lifecycle as periodic repair; capture remains connected while missed history is fetched, and shutdown cancels and joins the repair
+- with `--repair-on-start`, REST repair owns history cursors for that tail session; live events still update messages and live freshness immediately, but cannot advance history progress past missing messages. Periodic and subsequent startup repairs may therefore re-fetch already captured messages. This also preserves catch-up progress if repair is interrupted.
 - not available in Git-only mode (`discord.token_source = "none"`)
 - `discrawl --verbose tail` traces Gateway receipt, worker handling, scope
   filtering, and successful archive writes with event and Discord IDs but no

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -330,6 +330,7 @@ func (r *runtime) runTail(args []string) error {
 	fs := flag.NewFlagSet("tail", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	repairEvery := fs.Duration("repair-every", mustDuration(r.cfg.Sync.RepairEvery), "")
+	repairOnStart := fs.Bool("repair-on-start", false, "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
 	embedLive := fs.Bool("embed-live", false, "")
 	replayFailuresOnly := fs.Bool("replay-failures-only", false, "")
@@ -357,6 +358,14 @@ func (r *runtime) runTail(args []string) error {
 	}
 	if *embedLive && *replayFailuresOnly {
 		return usageErr(errors.New("--embed-live cannot be combined with --replay-failures-only"))
+	}
+	if *repairOnStart && *replayFailuresOnly {
+		return usageErr(errors.New("--repair-on-start cannot be combined with --replay-failures-only"))
+	}
+	if configurable, ok := r.syncer.(tailStartupRepairConfigurer); ok {
+		configurable.SetTailRepairOnStart(*repairOnStart)
+	} else if *repairOnStart {
+		return errors.New("startup tail repair is unavailable")
 	}
 	if *embedLive && !r.cfg.Search.Embeddings.Enabled {
 		return usageErr(errors.New("--embed-live requires embeddings enabled in config"))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -306,6 +306,10 @@ type tailEmbeddingsConfigurer interface {
 	SetTailEmbeddings(bool)
 }
 
+type tailStartupRepairConfigurer interface {
+	SetTailRepairOnStart(bool)
+}
+
 type tailMessageFailureReplayer interface {
 	ReplayTailMessageFailures(context.Context, []string, int) (syncer.TailMessageReplayStats, error)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3692,6 +3692,7 @@ type fakeSyncService struct {
 	includeCategoryIDs    []string
 	repairOffset          time.Duration
 	tailEmbeddings        bool
+	tailRepairOnStart     bool
 	callTailReady         bool
 	tailReadyCalls        int
 	tailReady             func(context.Context) error
@@ -3740,6 +3741,10 @@ func (f *fakeSyncService) SetTailReadyCallback(fn func(context.Context) error) {
 
 func (f *fakeSyncService) SetTailEmbeddings(enabled bool) {
 	f.tailEmbeddings = enabled
+}
+
+func (f *fakeSyncService) SetTailRepairOnStart(enabled bool) {
+	f.tailRepairOnStart = enabled
 }
 
 func (f *fakeSyncService) SetAttachmentTextEnabled(enabled bool) {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -130,11 +130,12 @@ Sync Discord or desktop-cache data into the local archive.
 Configure Discord collection scope with sync.include_category_ids,
 sync.exclude_channel_ids, and sync.exclude_channel_kinds; exclusions win.
 `,
-	"tail": `Usage: discrawl tail [--repair-every DURATION] [--with-embeddings] [--embed-live] [--guild ID|--guilds IDS] [--replay-failures-only [--replay-limit N]]
+	"tail": `Usage: discrawl tail [--repair-every DURATION] [--repair-on-start] [--with-embeddings] [--embed-live] [--guild ID|--guilds IDS] [--replay-failures-only [--replay-limit N]]
 
 Continuously archive new Discord messages.
 Use --with-embeddings to queue live, replayed, and repair messages for embedding.
 Use --embed-live to also process embeddings continuously without pausing capture.
+Use --repair-on-start to catch up missed history as soon as the Gateway is connected.
 The sync.include_category_ids, sync.exclude_channel_ids, and
 sync.exclude_channel_kinds settings apply to live events and repair syncs.
 `,

--- a/internal/cli/startup_repair_test.go
+++ b/internal/cli/startup_repair_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTailStartupRepairIsExplicitAndIncompatibleWithReplayOnly(t *testing.T) {
+	for _, args := range [][]string{{"tail"}, {"tail", "--repair-on-start", "--repair-every", "0"}, {"tail", "--repair-on-start", "--replay-failures-only"}} {
+		_, path := writeTestConfig(t, t.TempDir())
+		fake := &fakeSyncService{callTailReady: true}
+		rt := tailTestRuntime(t.Context(), path, fake)
+		err := rt.dispatch(args)
+		if args[len(args)-1] == "--replay-failures-only" {
+			require.ErrorContains(t, err, "cannot be combined")
+			require.Zero(t, fake.tailCalls)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, len(args) > 1, fake.tailRepairOnStart)
+		require.Equal(t, 1, fake.tailCalls)
+	}
+}

--- a/internal/syncer/startup_repair_test.go
+++ b/internal/syncer/startup_repair_test.go
@@ -1,0 +1,140 @@
+package syncer
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	discordclient "github.com/openclaw/discrawl/internal/discord"
+	"github.com/openclaw/discrawl/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+type startupTailClient struct {
+	*fakeClient
+	serve func(context.Context, discordclient.EventHandler) error
+}
+
+func (c *startupTailClient) Tail(ctx context.Context, handler discordclient.EventHandler) error {
+	return c.serve(ctx, handler)
+}
+
+func TestStartupRepairRecoversGapWhileCaptureContinues(t *testing.T) {
+	for _, interval := range []time.Duration{0, 6 * time.Hour} {
+		t.Run(interval.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			s, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+			require.NoError(t, err)
+			defer func() { _ = s.Close() }()
+			require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{ID: "1", GuildID: "g1", ChannelID: "c1", Content: "before restart", NormalizedContent: "before restart"}))
+			blocked := make(chan struct{})
+			client := &startupTailClient{fakeClient: &fakeClient{
+				guilds:         []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+				guildByID:      map[string]*discordgo.Guild{"g1": {ID: "g1", Name: "Guild"}},
+				channels:       map[string][]*discordgo.Channel{"g1": {{ID: "c1", GuildID: "g1", Type: discordgo.ChannelTypeGuildText}}},
+				messages:       map[string][]*discordgo.Message{"c1": {{ID: "10", GuildID: "g1", ChannelID: "c1", Content: "offline message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}}},
+				messageBlocks:  map[string]chan struct{}{"c1": blocked},
+				messageStarted: make(chan string, 1),
+			}}
+			captured := make(chan struct{})
+			client.serve = func(ctx context.Context, handler discordclient.EventHandler) error {
+				if err := handler.(discordclient.TailReadyHandler).OnTailReady(ctx); err != nil {
+					return err
+				}
+				select {
+				case <-client.messageStarted:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				// REST is blocked, but the connected Gateway still writes events.
+				if err := handler.OnMessageCreate(ctx, &discordgo.Message{ID: "11", GuildID: "g1", ChannelID: "c1", Content: "live message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}); err != nil {
+					return err
+				}
+				close(captured)
+				close(blocked)
+				<-ctx.Done()
+				return nil
+			}
+			svc := New(client, s, nil)
+			svc.SetTailRepairOnStart(true)
+			svc.SetTailEmbeddings(true)
+			done := make(chan error, 1)
+			go func() { done <- svc.RunTail(ctx, []string{"g1"}, interval) }()
+			select {
+			case <-captured:
+			case <-ctx.Done():
+				t.Fatal("capture or immediate startup repair did not progress")
+			}
+			require.Eventually(t, func() bool {
+				var count int
+				_ = s.DB().QueryRowContext(ctx, `select count(*) from messages where id in ('10','11')`).Scan(&count)
+				return count == 2
+			}, 2*time.Second, 10*time.Millisecond)
+			cancel()
+			require.NoError(t, <-done)
+			var queued int
+			require.NoError(t, s.DB().QueryRowContext(t.Context(), `select count(*) from embedding_jobs where message_id in ('10','11')`).Scan(&queued))
+			require.Equal(t, 2, queued)
+		})
+	}
+}
+
+func TestStartupRepairWaitsForReadyAndJoinsOnShutdown(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	connected, allowReady, started, joined := make(chan struct{}), make(chan struct{}), make(chan struct{}), make(chan struct{})
+	client := &startupTailClient{fakeClient: &fakeClient{}, serve: func(ctx context.Context, h discordclient.EventHandler) error {
+		close(connected)
+		select {
+		case <-allowReady:
+		case <-ctx.Done():
+			return nil
+		}
+		if err := h.(discordclient.TailReadyHandler).OnTailReady(ctx); err != nil {
+			return err
+		}
+		<-ctx.Done()
+		return nil
+	}}
+	svc := New(client, s, nil)
+	svc.SetTailRepairOnStart(true)
+	var ready atomic.Bool
+	svc.SetTailReadyCallback(func(context.Context) error { ready.Store(true); return nil })
+	svc.tailRepair = func(ctx context.Context, opts SyncOptions) (SyncStats, error) {
+		if !ready.Load() {
+			t.Error("repair started before ownership-ready callback")
+		}
+		close(started)
+		<-ctx.Done()
+		close(joined)
+		return SyncStats{}, ctx.Err()
+	}
+	done := make(chan error, 1)
+	go func() { done <- svc.RunTail(ctx, nil, time.Millisecond) }()
+	<-connected
+	select {
+	case <-started:
+		t.Fatal("repair ran before Gateway ready")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(allowReady)
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("startup repair did not start")
+	}
+	cancel()
+	require.NoError(t, <-done)
+	select {
+	case <-joined:
+	default:
+		t.Fatal("repair was not joined before return")
+	}
+}

--- a/internal/syncer/startup_repair_test.go
+++ b/internal/syncer/startup_repair_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -24,62 +25,79 @@ func (c *startupTailClient) Tail(ctx context.Context, handler discordclient.Even
 
 func TestStartupRepairRecoversGapWhileCaptureContinues(t *testing.T) {
 	for _, interval := range []time.Duration{0, 6 * time.Hour} {
-		t.Run(interval.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-			defer cancel()
-			s, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
-			require.NoError(t, err)
-			defer func() { _ = s.Close() }()
-			require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{ID: "1", GuildID: "g1", ChannelID: "c1", Content: "before restart", NormalizedContent: "before restart"}))
-			blocked := make(chan struct{})
-			client := &startupTailClient{fakeClient: &fakeClient{
-				guilds:         []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
-				guildByID:      map[string]*discordgo.Guild{"g1": {ID: "g1", Name: "Guild"}},
-				channels:       map[string][]*discordgo.Channel{"g1": {{ID: "c1", GuildID: "g1", Type: discordgo.ChannelTypeGuildText}}},
-				messages:       map[string][]*discordgo.Message{"c1": {{ID: "10", GuildID: "g1", ChannelID: "c1", Content: "offline message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}}},
-				messageBlocks:  map[string]chan struct{}{"c1": blocked},
-				messageStarted: make(chan string, 1),
-			}}
-			captured := make(chan struct{})
-			client.serve = func(ctx context.Context, handler discordclient.EventHandler) error {
-				if err := handler.(discordclient.TailReadyHandler).OnTailReady(ctx); err != nil {
-					return err
+		for _, liveFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/live-first=%t", interval, liveFirst), func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				s, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+				require.NoError(t, err)
+				defer func() { _ = s.Close() }()
+				require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{ID: "1", GuildID: "g1", ChannelID: "c1", Content: "before restart", NormalizedContent: "before restart"}))
+				require.NoError(t, s.SetSyncState(ctx, channelLatestScope("c1"), "1"))
+				blocked := make(chan struct{})
+				client := &startupTailClient{fakeClient: &fakeClient{
+					guilds:         []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+					guildByID:      map[string]*discordgo.Guild{"g1": {ID: "g1", Name: "Guild"}},
+					channels:       map[string][]*discordgo.Channel{"g1": {{ID: "c1", GuildID: "g1", Type: discordgo.ChannelTypeGuildText, LastMessageID: "11"}}},
+					messages:       map[string][]*discordgo.Message{"c1": {{ID: "10", GuildID: "g1", ChannelID: "c1", Content: "offline message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}}},
+					messageBlocks:  map[string]chan struct{}{"c1": blocked},
+					messageStarted: make(chan string, 1),
+				}}
+				captured := make(chan struct{})
+				client.serve = func(ctx context.Context, handler discordclient.EventHandler) error {
+					capture := func() error {
+						if err := handler.OnMessageCreate(ctx, &discordgo.Message{ID: "11", GuildID: "g1", ChannelID: "c1", Content: "live message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}); err != nil {
+							return err
+						}
+						close(captured)
+						return nil
+					}
+					if liveFirst {
+						if err := capture(); err != nil {
+							return err
+						}
+					}
+					if err := handler.(discordclient.TailReadyHandler).OnTailReady(ctx); err != nil {
+						return err
+					}
+					select {
+					case <-client.messageStarted:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					// REST is blocked, but the connected Gateway still writes events.
+					if !liveFirst {
+						if err := capture(); err != nil {
+							return err
+						}
+					}
+					close(blocked)
+					<-ctx.Done()
+					return nil
 				}
+				svc := New(client, s, nil)
+				svc.SetTailRepairOnStart(true)
+				svc.SetTailEmbeddings(true)
+				done := make(chan error, 1)
+				go func() { defer close(done); done <- svc.RunTail(ctx, []string{"g1"}, interval) }()
+				defer func() { cancel(); <-done }()
 				select {
-				case <-client.messageStarted:
+				case <-captured:
 				case <-ctx.Done():
-					return ctx.Err()
+					t.Fatal("capture or immediate startup repair did not progress")
 				}
-				// REST is blocked, but the connected Gateway still writes events.
-				if err := handler.OnMessageCreate(ctx, &discordgo.Message{ID: "11", GuildID: "g1", ChannelID: "c1", Content: "live message", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}); err != nil {
-					return err
-				}
-				close(captured)
-				close(blocked)
-				<-ctx.Done()
-				return nil
-			}
-			svc := New(client, s, nil)
-			svc.SetTailRepairOnStart(true)
-			svc.SetTailEmbeddings(true)
-			done := make(chan error, 1)
-			go func() { done <- svc.RunTail(ctx, []string{"g1"}, interval) }()
-			select {
-			case <-captured:
-			case <-ctx.Done():
-				t.Fatal("capture or immediate startup repair did not progress")
-			}
-			require.Eventually(t, func() bool {
-				var count int
-				_ = s.DB().QueryRowContext(ctx, `select count(*) from messages where id in ('10','11')`).Scan(&count)
-				return count == 2
-			}, 2*time.Second, 10*time.Millisecond)
-			cancel()
-			require.NoError(t, <-done)
-			var queued int
-			require.NoError(t, s.DB().QueryRowContext(t.Context(), `select count(*) from embedding_jobs where message_id in ('10','11')`).Scan(&queued))
-			require.Equal(t, 2, queued)
-		})
+				require.Eventually(t, func() bool {
+					var count int
+					_ = s.DB().QueryRowContext(ctx, `select count(*) from messages where id in ('10','11')`).Scan(&count)
+					return count == 2
+				}, 2*time.Second, 10*time.Millisecond)
+				cancel()
+				require.NoError(t, <-done)
+				var queued int
+				require.NoError(t, s.DB().QueryRowContext(t.Context(), `select count(*) from embedding_jobs where message_id in ('10','11')`).Scan(&queued))
+				require.Equal(t, 2, queued)
+			})
+		}
 	}
 }
 
@@ -137,4 +155,63 @@ func TestStartupRepairWaitsForReadyAndJoinsOnShutdown(t *testing.T) {
 	default:
 		t.Fatal("repair was not joined before return")
 	}
+}
+
+func TestStartupRepairCursorSurvivesInterruptedOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	s, err := store.Open(t.Context(), path)
+	require.NoError(t, err)
+	require.NoError(t, s.SetSyncState(t.Context(), channelLatestScope("c1"), "1"))
+	handler := &tailHandler{store: s, preserveHistoryCursor: true}
+	message := &discordgo.Message{ID: "11", GuildID: "g1", ChannelID: "c1", Content: "live before repair", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}}
+	require.NoError(t, handler.OnMessageCreate(t.Context(), message))
+	cursor, err := s.GetSyncState(t.Context(), channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "1", cursor)
+	freshness, err := s.GetSyncState(t.Context(), "tail:last_event")
+	require.NoError(t, err)
+	require.Equal(t, "11", freshness)
+	// The first owner exits before REST repair can persist anything.
+	require.NoError(t, s.Close())
+	s, err = store.Open(t.Context(), path)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	client := &startupTailClient{fakeClient: &fakeClient{
+		guilds:    []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{"g1": {ID: "g1", Name: "Guild"}},
+		channels:  map[string][]*discordgo.Channel{"g1": {{ID: "c1", GuildID: "g1", Type: discordgo.ChannelTypeGuildText, LastMessageID: "11"}}},
+		messages: map[string][]*discordgo.Message{"c1": {
+			message,
+			{ID: "10", GuildID: "g1", ChannelID: "c1", Content: "missed offline", Timestamp: time.Now(), Author: &discordgo.User{ID: "u1"}},
+		}},
+	}, serve: func(ctx context.Context, h discordclient.EventHandler) error {
+		if err := h.(discordclient.TailReadyHandler).OnTailReady(ctx); err != nil {
+			return err
+		}
+		<-ctx.Done()
+		return nil
+	}}
+	svc := New(client, s, nil)
+	svc.SetTailRepairOnStart(true)
+	done := make(chan error, 1)
+	go func() { defer close(done); done <- svc.RunTail(ctx, []string{"g1"}, 6*time.Hour) }()
+	defer func() { cancel(); <-done }()
+	require.Eventually(t, func() bool {
+		var count int
+		_ = s.DB().QueryRowContext(ctx, `select count(*) from messages where id in ('10','11')`).Scan(&count)
+		cursor, _ := s.GetSyncState(ctx, channelLatestScope("c1"))
+		return count == 2 && cursor == "11"
+	}, 2*time.Second, 10*time.Millisecond)
+	// Later live events still cannot claim unverified history coverage.
+	handler.store = s
+	later := *message
+	later.ID = "12"
+	require.NoError(t, handler.OnMessageCreate(ctx, &later))
+	cursor, err = s.GetSyncState(ctx, channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "11", cursor)
+	cancel()
+	require.NoError(t, <-done)
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -50,6 +50,7 @@ type Syncer struct {
 	tailRepairOffsetMu    sync.RWMutex
 	tailRepairOffset      time.Duration
 	tailEmbeddings        bool
+	tailRepairOnStart     bool
 	channelExclusions     channelExclusions
 }
 
@@ -73,6 +74,10 @@ type SyncOptions struct {
 
 func (s *Syncer) SetTailReadyCallback(fn func(context.Context) error) {
 	s.tailReady = fn
+}
+
+func (s *Syncer) SetTailRepairOnStart(enabled bool) {
+	s.tailRepairOnStart = enabled
 }
 
 func (s *Syncer) SetChannelExclusions(channelIDs, channelKinds []string) {

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -30,7 +30,22 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 	if err := handler.seedChannelExclusions(ctx); err != nil {
 		return fmt.Errorf("seed tail channel exclusions: %w", err)
 	}
-	if repairEvery <= 0 {
+	var startupReady <-chan struct{}
+	if s.tailRepairOnStart {
+		ready := make(chan struct{})
+		startupReady = ready
+		var once sync.Once
+		handler.onReady = func(ctx context.Context) error {
+			if s.tailReady != nil {
+				if err := s.tailReady(ctx); err != nil {
+					return err
+				}
+			}
+			once.Do(func() { close(ready) })
+			return nil
+		}
+	}
+	if repairEvery <= 0 && !s.tailRepairOnStart {
 		return s.client.Tail(ctx, handler)
 	}
 	tailCtx, cancelTail := context.WithCancel(ctx)
@@ -45,8 +60,13 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 	go func() {
 		tailDone <- s.client.Tail(tailCtx, handler)
 	}()
-	repairTimer := time.NewTimer(nextTailRepairDelay(time.Now(), repairEvery, s.repairOffset()))
-	defer repairTimer.Stop()
+	var repairTimer *time.Timer
+	var repairTick <-chan time.Time
+	if repairEvery > 0 {
+		repairTimer = time.NewTimer(nextTailRepairDelay(time.Now(), repairEvery, s.repairOffset()))
+		defer repairTimer.Stop()
+		repairTick = repairTimer.C
+	}
 	var activeRepair *tailRepairRun
 	var repairDone <-chan tailRepairResult
 	for {
@@ -78,8 +98,18 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 			s.logTailRepairResult(result)
 			activeRepair = nil
 			repairDone = nil
-		case <-repairTimer.C:
-			if activeRepair != nil {
+		case <-startupReady:
+			startupReady = nil
+			// Capture is connected before REST catch-up, so events arriving
+			// during the repair are still observed by this same writer owner.
+			if ctx.Err() == nil {
+				activeRepair = s.startTailRepair(ctx, guildIDs)
+				if activeRepair != nil {
+					repairDone = activeRepair.done
+				}
+			}
+		case <-repairTick:
+			if activeRepair != nil || startupReady != nil {
 				repairTimer.Reset(nextTailRepairDelay(time.Now(), repairEvery, s.repairOffset()))
 				continue
 			}

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -23,6 +23,7 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 		client:                s.client,
 		attachmentTextEnabled: s.attachmentTextEnabled,
 		enqueueEmbeddings:     s.tailEmbeddings,
+		preserveHistoryCursor: s.tailRepairOnStart,
 		onReady:               s.tailReady,
 		logger:                s.logger,
 		exclusions:            s.channelExclusions,
@@ -238,6 +239,7 @@ type tailHandler struct {
 	client                Client
 	attachmentTextEnabled bool
 	enqueueEmbeddings     bool
+	preserveHistoryCursor bool
 	failureLedgerTimeout  time.Duration
 	onReady               func(context.Context) error
 	logger                *slog.Logger
@@ -323,9 +325,15 @@ func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Messag
 	if err := t.store.SetSyncState(ctx, "tail:last_event", msg.ID); err != nil {
 		return err
 	}
-	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageCursorAdvance)
-	if err := t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID); err != nil {
-		return err
+	// In startup-repair mode only REST advances history coverage. An isolated
+	// Gateway event cannot prove the intervening history was fetched. Keeping
+	// this rule for the lifetime of the tail also makes interrupted repairs
+	// recoverable by the next owner without a second cursor or checkpoint.
+	if !t.preserveHistoryCursor {
+		discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageCursorAdvance)
+		if err := t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID); err != nil {
+			return err
+		}
 	}
 	if err := t.resolveMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, "create"); err != nil {
 		return err


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users restarting `discrawl tail` after downtime can wait until the next periodic repair for missed messages to appear. A six-hour repair interval can leave that history gap for hours, requiring an external pre-start sync.

## Why This Change Was Made

Add opt-in `tail --repair-on-start`. After the Gateway connects and the existing ownership-ready callback succeeds, request one immediate latest-only repair through the existing serialized repair lifecycle. Capture remains connected during REST catch-up, and both use the same archive writer owner. Shutdown cancels and joins the repair through the existing bounded cleanup path.

In this opt-in mode, REST alone advances history cursors for the lifetime of the tail; live events still update messages and live freshness immediately. A new live message therefore cannot mark offline history as fetched, and an interrupted owner leaves a recoverable cursor for the next startup. This reuses existing state without another cursor or checkpoint.

## User Impact

Service managers can start Discrawl directly and recover restart gaps without a separate sync process. Default behavior is unchanged. Repairs in the new mode may re-fetch already captured messages because history progress belongs to REST. The option also works with `--repair-every 0` for startup-only repair and rejects replay-only mode.

## Evidence

- Temporary-archive tests recover an offline message with periodic repair disabled and with a six-hour interval, while a new Gateway message is written during a blocked REST request. Both messages are queued for embedding.
- Tests verify repair waits for Gateway readiness and the ownership callback, does not overlap periodic repair, and is joined before shutdown returns.
- CLI coverage verifies explicit selection, default behavior, and replay-only incompatibility.
- Full Go race suite, lint, module tidy, and unchanged dependency-file checks passed. No live archive is used by tests.
- Final structured autoreview completed with no actionable findings.
- The initial ClawSweeper cursor finding was reproduced: a live event arriving before the repair reads channel state caused the offline message to remain missing. The corrected regression passes for both zero and six-hour repair intervals, and a close/reopen test proves an interrupted owner retains recoverable progress.
